### PR TITLE
add vehicle-to-grid capability to GreedyMarket

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -128,6 +128,7 @@ class VehicleType:
         optional_keys = [
             ('min_charging_power', float, 0.0),
             ('battery_efficiency', float, 0.95),
+            ('v2g', bool, False),
         ]
         util.set_attr_from_dict(obj, self, keys, optional_keys)
 

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -60,7 +60,7 @@ class Scenario:
         begin = datetime.datetime.now()
         for step_i in range(self.n_intervals):
 
-            if options["timing"]:
+            if options.get("timing", False):
                 # show estimated time until finished after each simulation step
                 # get time since start
                 dt = datetime.datetime.now() - begin

--- a/src/strategies/greedy_market.py
+++ b/src/strategies/greedy_market.py
@@ -201,10 +201,13 @@ class GreedyMarket(Strategy):
             power_vec = [0]*len(timesteps)
 
             # iterate timesteps by order of cheapest price
-            for sorted_idx, (cost, ts_idx) in enumerate(sorted_ts):
+            sorted_idx = -1
+            for cost, ts_idx in sorted_ts:
                 if need_charging == 0:
                     # all standing times satisfied -> no need to charge
                     continue
+
+                sorted_idx += 1
 
                 power = 0
                 ts_info = timesteps[ts_idx]
@@ -399,13 +402,13 @@ class GreedyMarket(Strategy):
                         if cur_info["power"] > 0:
                             # charge
                             info = sim_battery.load(self.interval, cur_info["power"])
-                            power_vec[v2g_ts_idx + cur_idx] = info["avg_power"]
+                            power_vec[ts_idx + cur_idx] = info["avg_power"]
                         if cur_info["power"] < 0:
                             # discharge
                             power = -cur_info["power"]
                             limit = self.DISCHARGE_LIMIT
                             info = sim_battery.unload(self.interval, power, self.DISCHARGE_LIMIT)
-                            power_vec[v2g_ts_idx + cur_idx] = info["avg_power"]
+                            power_vec[ts_idx + cur_idx] = info["avg_power"]
                         cur_info["soc"] = sim_battery.soc
                         is_charged = sim_battery.soc >= desired_soc - self.EPS
                         charged_vec[cur_info["stand_idx"]] = is_charged

--- a/src/strategies/greedy_market.py
+++ b/src/strategies/greedy_market.py
@@ -252,7 +252,8 @@ class GreedyMarket(Strategy):
                         if cur_info["power"] > 0:
                             sim_battery.load(self.interval, cur_info["power"], desired_soc)
                         cur_info["soc"] = sim_battery.soc
-                        charged_vec[cur_info["stand_idx"]] = sim_battery.soc >= desired_soc - self.EPS
+                        is_charged = sim_battery.soc >= desired_soc - self.EPS
+                        charged_vec[cur_info["stand_idx"]] = is_charged
 
                 # allocate charge (no double-spending)
                 ts_info["power"] -= power
@@ -392,7 +393,8 @@ class GreedyMarket(Strategy):
                             target_soc = cur_info["desired_soc"] if self.SAFE_DISCHARGE else 0
                             sim_battery.unload(self.interval, -cur_info["power"], target_soc)
                         cur_info["soc"] = sim_battery.soc
-                        charged_vec[cur_info["stand_idx"]] = sim_battery.soc >= desired_soc - self.EPS
+                        is_charged = sim_battery.soc >= desired_soc - self.EPS
+                        charged_vec[cur_info["stand_idx"]] = is_charged
 
                     if ts_idx == 0:
                         # current timestep: make note of charge (can be charged for real later)


### PR DESCRIPTION
- add VehicleType attribute "v2g" (boolean, default false)
- after GreedyMarket has raised vehicle to safe SoC level within horizon, try to discharge V2G vehicles at highest price points
- can charge again to always leave with desired SoC