### PR TITLE
Feature: allow negative SoC

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -28,7 +28,7 @@ def simulate(args):
         'visual': args.visual,
         'margin': args.margin,
         'output': args.output,
-        'negative_soc': args.allow_negative_soc,
+        'allow_negative_soc': args.allow_negative_soc,
     }
 
     # parse strategy options

--- a/simulate.py
+++ b/simulate.py
@@ -28,7 +28,6 @@ def simulate(args):
         'visual': args.visual,
         'margin': args.margin,
         'output': args.output,
-        'allow_negative_soc': args.allow_negative_soc,
     }
 
     # parse strategy options
@@ -77,7 +76,6 @@ if __name__ == '__main__':
     parser.add_argument('--eta', action='store_true',
                         help='Show estimated time to finish simulation after each step, \
                         instead of progress bar. Not recommended for fast computations.')
-    parser.add_argument('--allow_negative_soc', action='store_true', help='Generate output file')
     parser.add_argument('--output', '-o', help='Generate output file')
     parser.add_argument('--config', help='Use config file to set arguments')
     args = parser.parse_args()

--- a/simulate.py
+++ b/simulate.py
@@ -28,6 +28,7 @@ def simulate(args):
         'visual': args.visual,
         'margin': args.margin,
         'output': args.output,
+        'negative_soc': args.allow_negative_soc,
     }
 
     # parse strategy options
@@ -76,6 +77,7 @@ if __name__ == '__main__':
     parser.add_argument('--eta', action='store_true',
                         help='Show estimated time to finish simulation after each step, \
                         instead of progress bar. Not recommended for fast computations.')
+    parser.add_argument('--allow_negative_soc', action='store_true', help='Generate output file')
     parser.add_argument('--output', '-o', help='Generate output file')
     parser.add_argument('--config', help='Use config file to set arguments')
     args = parser.parse_args()

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -22,6 +22,7 @@ class Strategy():
         self.current_time = start_time - self.interval
         # relative allowed difference between battery SoC and desired SoC when leaving
         self.margin = 0.05
+        self.allow_negative_soc = False
         # tolerance for floating point comparison
         self.EPS = 1e-5
         # update optional
@@ -86,12 +87,14 @@ class Strategy():
                     vehicle.battery.soc += vehicle.soc_delta
                     if vehicle.battery.soc + self.EPS < 0:
                         if self.allow_negative_soc:
-                            print('Warning: SOC of vehicle {} became negative. SOC is {}, continuing with SOC = 0'
+                            print('Warning: SOC of vehicle {} became negative. SOC is {},'
+                                  'continuing with SOC = 0'
                                   .format(ev.vehicle_id, vehicle.battery.soc))
                             vehicle.battery.soc = 0
                         else:
                             raise ValueError(
-                                'SOC of vehicle {} should not be negative. SOC is {}, soc_delta was {}'
+                                'SOC of vehicle {} should not be negative. '
+                                'SOC is {}, soc_delta was {}'
                                 .format(ev.vehicle_id, vehicle.battery.soc, vehicle.soc_delta))
                     delattr(vehicle, 'soc_delta')
             else:

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -87,12 +87,12 @@ class Strategy():
                     vehicle.battery.soc += vehicle.soc_delta
                     if vehicle.battery.soc + self.EPS < 0:
                         if self.allow_negative_soc:
-                            print('Warning: SOC of vehicle {} became negative. SOC is {},'
+                            print('Warning: SOC of vehicle {} became negative at {}. SOC is {},'
                                   'continuing with SOC = 0'
-                                  .format(ev.vehicle_id, vehicle.battery.soc))
+                                  .format(ev.vehicle_id, self.current_time, vehicle.battery.soc))
                             vehicle.battery.soc = 0
                         else:
-                            raise ValueError(
+                            raise RuntimeError(
                                 'SOC of vehicle {} should not be negative. '
                                 'SOC is {}, soc_delta was {}'
                                 .format(ev.vehicle_id, vehicle.battery.soc, vehicle.soc_delta))

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -84,9 +84,15 @@ class Strategy():
                     assert vehicle.connected_charging_station is not None
                     assert hasattr(vehicle, 'soc_delta')
                     vehicle.battery.soc += vehicle.soc_delta
-                    assert vehicle.battery.soc + self.EPS >= 0, (
-                        'SOC of vehicle {} should not be negative. SOC is {}, soc_delta was {}'
-                        .format(ev.vehicle_id, vehicle.battery.soc, vehicle.soc_delta))
+                    if vehicle.battery.soc + self.EPS < 0:
+                        if self.allow_negative_soc:
+                            print('Warning: SOC of vehicle {} became negative. SOC is {}, continuing with SOC = 0'
+                                  .format(ev.vehicle_id, vehicle.battery.soc))
+                            vehicle.battery.soc = 0
+                        else:
+                            raise ValueError(
+                                'SOC of vehicle {} should not be negative. SOC is {}, soc_delta was {}'
+                                .format(ev.vehicle_id, vehicle.battery.soc, vehicle.soc_delta))
                     delattr(vehicle, 'soc_delta')
             else:
                 raise Exception("Unknown event type: {}".format(ev))

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -87,7 +87,7 @@ class Strategy():
                     vehicle.battery.soc += vehicle.soc_delta
                     if vehicle.battery.soc + self.EPS < 0:
                         if self.allow_negative_soc:
-                            print('Warning: SOC of vehicle {} became negative at {}. SOC is {},'
+                            print('Warning: SOC of vehicle {} became negative at {}. SOC is {}, '
                                   'continuing with SOC = 0'
                                   .format(ev.vehicle_id, self.current_time, vehicle.battery.soc))
                             vehicle.battery.soc = 0


### PR DESCRIPTION
I added another parser argument in simulate that makes the simulation continue despite negative SoCs.

This PR closes #17 