### PR TITLE
Fix for Balanced Market V2G Oscialltion

### DIFF
--- a/src/strategies/balanced_market.py
+++ b/src/strategies/balanced_market.py
@@ -296,6 +296,8 @@ class BalancedMarket(Strategy):
                         discharging_stations.append(cs_id)
                     charging_stations[cs_id] = gc.add_load(cs_id, avg_power)
                     cs.current_power += avg_power
+                    # current timestep will not be taken into account again
+                    break
                 # end apply power
             # end loop V2G
 

--- a/src/strategies/balanced_market.py
+++ b/src/strategies/balanced_market.py
@@ -201,6 +201,8 @@ class BalancedMarket(Strategy):
                     cs.current_power += avg_power
                     # don't have to simulate further
                     break
+            else:
+                sorted_idx = 0
 
             # normal charging done
 

--- a/src/strategies/balanced_market.py
+++ b/src/strategies/balanced_market.py
@@ -210,7 +210,7 @@ class BalancedMarket(Strategy):
             # and stop once it reaches charging timestep
             # off-by-one: v2g_sorted_idx is immediately decreased by one
             v2g_sorted_idx = len(sorted_ts)
-            while vehicle.vehicle_type.v2g and v2g_sorted_idx > (sorted_idx + 1):
+            while vehicle.vehicle_type.v2g and v2g_sorted_idx > sorted_idx:
                 sim_power = None
                 v2g_sorted_idx -= 1
                 v2g_cost, v2g_ts_idx = sorted_ts[v2g_sorted_idx]


### PR DESCRIPTION
### Three changes:

1. If the current timestep is not part of the balanced charging timespan, do not block that timespan for V2G simulation.
2. Off by one error. If v2g_sorted_idx cannot go never be 0, there will never be discharging at the end of a standing time.       (see screenshots for visualization)
![Before PR](https://user-images.githubusercontent.com/20053419/146226856-944af681-c1b7-4629-b22c-baf8aed3bc05.png)
*Before*
![After PR](https://user-images.githubusercontent.com/20053419/146227216-f25b61d6-25d2-4bcc-a023-43dc0888d807.png)
*After*

3. As far as I understand, once power was applied the current time step will not be taken into account again during V2G simulation. 


 