### PR TITLE
Show schedule or charge-windows only if appropriate strategy is used

### DIFF
--- a/src/scenario.py
+++ b/src/scenario.py
@@ -493,7 +493,7 @@ class Scenario:
                             v for k, v in extLoads[idx].items()
                             if k in self.events.external_load_lists])
                         row.append(round(sumExtLoads, round_to_places))
-                    # feed-in (negative since grid power is fed into system)
+                    # feed-in (negative since power is fed into system)
                     if any(feedInPower):
                         row.append(-1 * round(feedInPower[idx], round_to_places))
                     # batteries
@@ -607,19 +607,19 @@ class Scenario:
             ax.plot(xlabels, list([sum(cs) for cs in sum_cs]), label="CS")
             for name, values in loads.items():
                 ax.plot(xlabels, values, label=name)
-            # draw schedule
-            for gcID, schedule in gcWindowSchedule.items():
-                if all(s is not None for s in schedule):
-                    # schedule exists
-                    window_values = [v * int(max(totalLoad)) for v in schedule]
-                    ax.plot(xlabels, window_values, label="window {}".format(gcID), linestyle='--')
 
-            for gcID, schedule in gcPowerSchedule.items():
-                if any(s is not None for s in schedule):
-                    # schedule exists
-                    ax.plot(xlabels, schedule, label="Schedule {}".format(gcID))
+            # draw schedule or charge-windows
+            if type(strat).__name__ == "FlexWindow":
+                for gcID, schedule in gcWindowSchedule.items():
+                    if all(s is not None for s in schedule):
+                        window_values = [v * int(max(totalLoad)) for v in schedule]
+                        ax.plot(xlabels, window_values, label="Window {}".format(gcID), linestyle='--')
+            if type(strat).__name__ == "Schedule":
+                for gcID, schedule in gcPowerSchedule.items():
+                    if any(s is not None for s in schedule):
+                        ax.plot(xlabels, schedule, label="Schedule {}".format(gcID))
 
-            ax.plot(xlabels, totalLoad, label="total")
+            ax.plot(xlabels, totalLoad, label="Total")
             # ax.axhline(color='k', linestyle='--', linewidth=1)
             ax.set_title('Power')
             ax.set(ylabel='Power in kW')

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -612,8 +612,8 @@ class Scenario:
             if type(strat).__name__ == "FlexWindow":
                 for gcID, schedule in gcWindowSchedule.items():
                     if all(s is not None for s in schedule):
-                        window_values = [v * int(max(totalLoad)) for v in schedule]
-                        ax.plot(xlabels, window_values, label="Window {}".format(gcID), linestyle='--')
+                        w_values = [v * int(max(totalLoad)) for v in schedule]
+                        ax.plot(xlabels, w_values, label="Window {}".format(gcID), linestyle='--')
             if type(strat).__name__ == "Schedule":
                 for gcID, schedule in gcPowerSchedule.items():
                     if any(s is not None for s in schedule):

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -609,12 +609,12 @@ class Scenario:
                 ax.plot(xlabels, values, label=name)
 
             # draw schedule or charge-windows
-            if strategy_name == "flex_window":
+            if strat.uses_window:
                 for gcID, schedule in gcWindowSchedule.items():
                     if all(s is not None for s in schedule):
                         w_values = [v * int(max(totalLoad)) for v in schedule]
                         ax.plot(xlabels, w_values, label="Window {}".format(gcID), linestyle='--')
-            if strategy_name == "schedule":
+            if strat.uses_schedule:
                 for gcID, schedule in gcPowerSchedule.items():
                     if any(s is not None for s in schedule):
                         ax.plot(xlabels, schedule, label="Schedule {}".format(gcID))

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -609,12 +609,12 @@ class Scenario:
                 ax.plot(xlabels, values, label=name)
 
             # draw schedule or charge-windows
-            if type(strat).__name__ == "FlexWindow":
+            if strategy_name == "flex_window":
                 for gcID, schedule in gcWindowSchedule.items():
                     if all(s is not None for s in schedule):
                         w_values = [v * int(max(totalLoad)) for v in schedule]
                         ax.plot(xlabels, w_values, label="Window {}".format(gcID), linestyle='--')
-            if type(strat).__name__ == "Schedule":
+            if strategy_name == "schedule":
                 for gcID, schedule in gcPowerSchedule.items():
                     if any(s is not None for s in schedule):
                         ax.plot(xlabels, schedule, label="Schedule {}".format(gcID))

--- a/src/strategies/flex_window.py
+++ b/src/strategies/flex_window.py
@@ -20,6 +20,7 @@ class FlexWindow(Strategy):
         assert (len(self.world_state.grid_connectors) == 1), "Only one grid connector supported"
         self.description = "Flex Window ({}, {} hour horizon)".format(
             self.LOAD_STRAT, self.HORIZON)
+        self.uses_window = True
 
         if self.LOAD_STRAT == "greedy":
             # charge vehicles in need first, then by order of departure

--- a/src/strategies/schedule.py
+++ b/src/strategies/schedule.py
@@ -22,6 +22,7 @@ class Schedule(Strategy):
 
         self.description = "schedule ({})".format(self.LOAD_STRAT)
         self.uses_schedule = True
+        
         if self.LOAD_STRAT == "greedy":
             self.sort_key = lambda v: (
                 v[0].battery.soc >= v[0].desired_soc,

--- a/src/strategies/schedule.py
+++ b/src/strategies/schedule.py
@@ -22,7 +22,7 @@ class Schedule(Strategy):
 
         self.description = "schedule ({})".format(self.LOAD_STRAT)
         self.uses_schedule = True
-        
+
         if self.LOAD_STRAT == "greedy":
             self.sort_key = lambda v: (
                 v[0].battery.soc >= v[0].desired_soc,

--- a/src/strategies/schedule.py
+++ b/src/strategies/schedule.py
@@ -21,6 +21,7 @@ class Schedule(Strategy):
         self.TS_per_hour = (timedelta(hours=1) / self.interval)
 
         self.description = "schedule ({})".format(self.LOAD_STRAT)
+        self.uses_schedule = True
         if self.LOAD_STRAT == "greedy":
             self.sort_key = lambda v: (
                 v[0].battery.soc >= v[0].desired_soc,

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -32,9 +32,12 @@ class Strategy():
         self.interval = kwargs.get('interval')  # required
         self.current_time = start_time - self.interval
         # relative allowed difference between battery SoC and desired SoC when leaving
-        self.margin = 0.05
+        self.margin = 0.1
         self.allow_negative_soc = False
-        self.V2G_POWER_FACTOR = 1.0
+        self.V2G_POWER_FACTOR = 0.5
+        # check if strategy uses grid signals & enable/disable plotting of schedule or window
+        self.uses_schedule = False
+        self.uses_window = False
         # tolerance for floating point comparison
         self.EPS = 1e-5
         # Reduce available power at each charging station to given fraction (0 - 1)


### PR DESCRIPTION
Fix #70 

**Changes proposed in this pull request**:
- The schedule or the charge-windows are now only shown in the first plot if the appropriate strategy is used.
- If neither flex_window or schedule is used, none is shown in the plot.

The following steps were realized, as well (required):
- [x] Correct linting with `fake8 path_to_script`
- [ ] Check if tests pass locally (`pytest ./src/tests.py`)

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done
