### PR TITLE
GC power now unaffected by future events

### DIFF
--- a/src/strategies/flex_window.py
+++ b/src/strategies/flex_window.py
@@ -90,7 +90,6 @@ class FlexWindow(Strategy):
                         cur_window = event.window
                 elif type(event) == events.EnergyFeedIn:
                     cur_feed_in[event.name] = event.value
-                    gc.current_loads[event.name] = -event.value
                 # vehicle events ignored (use vehicle info such as estimated_time_of_departure)
 
             ext_load = gc.get_avg_ext_load(cur_time, self.interval) - sum(cur_feed_in.values())


### PR DESCRIPTION
Fix #76

While looking into the future, the current GC power was affected by future feed-in events. Removed the command, as this does not make sense and it seems not to change charging results.