### PR TITLE
Fix calculation of arrival_time and added no_drive_days to cfg-file

### DIFF
--- a/examples/generate.cfg
+++ b/examples/generate.cfg
@@ -23,7 +23,7 @@ min_soc = 0.8
 # set buffer of 10% on top of needed SoC for next trip
 # buffer = 0.1
 # set weekday of vehicles not driving (Monday = 0, Sunday = 6)
-no_drive_day = 6
+no_drive_days = [6]
 # to set capability of V2G (default: false): change vehicle_types.json
 # minimum SoC to discharge to during V2G
 discharge_limit = 0.5

--- a/examples/generate.cfg
+++ b/examples/generate.cfg
@@ -20,7 +20,9 @@ days = 7
 interval = 15
 # set minimum allowed state of charge when leaving (default: 0.8)
 min_soc = 0.8
-# set weekday of vehicles not driving (Monday = 0)
+# set buffer of 10% on top of needed SoC for next trip
+# buffer = 0.1
+# set weekday of vehicles not driving (Monday = 0, Sunday = 6)
 no_drive_day = 6
 # to set capability of V2G (default: false): change vehicle_types.json
 # minimum SoC to discharge to during V2G

--- a/examples/generate.cfg
+++ b/examples/generate.cfg
@@ -20,8 +20,8 @@ days = 7
 interval = 15
 # set minimum allowed state of charge when leaving (default: 0.8)
 min_soc = 0.8
-# set buffer of 10% on top of needed SoC for next trip
-# buffer = 0.1
+# set weekday of vehicles not driving (Monday = 0)
+no_drive_day = 6
 # to set capability of V2G (default: false): change vehicle_types.json
 # minimum SoC to discharge to during V2G
 discharge_limit = 0.5

--- a/generate.py
+++ b/generate.py
@@ -36,7 +36,7 @@ def generate_trip(args):
     avg_start = vars(args).get("avg_start", "08:15")  # hh:mm
     std_start = vars(args).get("std_start", 0.42)  # hours
     min_start = vars(args).get("min_start", "07:00")
-    max_start = vars(args).get("max_start", "17:30")
+    max_start = vars(args).get("max_start", "09:30")
     # trip duration
     avg_driving = vars(args).get("avg_driving", 8.33)  # hours
     std_driving = vars(args).get("std_driving", 1.35)

--- a/generate.py
+++ b/generate.py
@@ -25,7 +25,7 @@ def generate_trip(args):
     :param args: input arguments
     :type args: argparse.Namespace
     :return:
-        start.time(), stop.time(), distance
+        start.time(), duration, distance
     """
     # distance of one trip
     avg_distance = vars(args).get("avg_distance", 47.13)  # km
@@ -218,14 +218,11 @@ def generate(args):
         if not path.exists(price_csv_path):
             print("Warning: price csv file '{}' does not exist yet".format(price_csv_path))
 
-    daily = datetime.timedelta(days=1)
-
     # count number of trips where desired_soc is above min_soc
     trips_above_min_soc = 0
 
     # create vehicle and price events
-    # each day (except Sunday), each vehicle leaves and returns after using some battery power
-
+    daily = datetime.timedelta(days=1)
     now = start - daily
     while now < stop + 2*daily:
         now += daily

--- a/generate.py
+++ b/generate.py
@@ -111,8 +111,8 @@ def generate(args):
 
     for count, vehicle_type in args.cars:
         assert vehicle_type in vehicle_types, \
-            'The given vehicle type "{}" is not valid. Should be one of {}' \
-                .format(vehicle_type, list(vehicle_types.keys()))
+            'The given vehicle type "{}" is not valid. ' \
+            'Should be one of {}'.format(vehicle_type, list(vehicle_types.keys()))
         vehicle_types[vehicle_type]["count"] = int(count)
 
     # VEHICLES WITH THEIR CHARGING STATION

--- a/generate.py
+++ b/generate.py
@@ -9,7 +9,6 @@ from os import path
 
 from src.util import set_options_from_config, datetime_from_isoformat
 
-
 DEFAULT_START_TIME = "2018-01-01T01:00:00+02:00"
 
 
@@ -111,9 +110,9 @@ def generate(args):
         vehicle_types = json.load(f)
 
     for count, vehicle_type in args.cars:
-        assert vehicle_type in vehicle_types,\
-            'The given vehicle type "{}" is not valid. Should be one of {}'\
-            .format(vehicle_type, list(vehicle_types.keys()))
+        assert vehicle_type in vehicle_types, \
+            'The given vehicle type "{}" is not valid. Should be one of {}' \
+                .format(vehicle_type, list(vehicle_types.keys()))
         vehicle_types[vehicle_type]["count"] = int(count)
 
     # VEHICLES WITH THEIR CHARGING STATION
@@ -145,7 +144,7 @@ def generate(args):
         else:
             # unlimited battery: set power directly
             max_power = c_rate
-        batteries["BAT{}".format(idx+1)] = {
+        batteries["BAT{}".format(idx + 1)] = {
             "parent": "GC1",
             "capacity": capacity,
             "charging_curve": [[0, max_power], [1, max_power]]
@@ -228,12 +227,13 @@ def generate(args):
     # create vehicle and price events
     daily = datetime.timedelta(days=1)
     now = start - daily
-    while now < stop + 2*daily:
+    while now < stop + 2 * daily:
         now += daily
 
         # create vehicle events for this day
         for v_id, v in vehicles.items():
-            if now.weekday() == args.no_drive_day:
+            no_driving = True if now.weekday() in args.no_drive_days else False
+            if no_driving:
                 break
 
             # get vehicle infos
@@ -297,10 +297,10 @@ def generate(args):
         # generate prices for the day
         if not args.include_price_csv and now < stop:
             morning = now + datetime.timedelta(hours=6)
-            evening_by_month = now + datetime.timedelta(hours=22-abs(6-now.month))
+            evening_by_month = now + datetime.timedelta(hours=22 - abs(6 - now.month))
             events['grid_operator_signals'] += [{
                 # day (6-evening): 15ct
-                "signal_time": max(start, now-daily).isoformat(),
+                "signal_time": max(start, now - daily).isoformat(),
                 "grid_connector_id": "GC1",
                 "start_time": morning.isoformat(),
                 "cost": {
@@ -309,7 +309,7 @@ def generate(args):
                 }
             }, {
                 # night (depending on month - 6): 5ct
-                "signal_time": max(start, now-daily).isoformat(),
+                "signal_time": max(start, now - daily).isoformat(),
                 "grid_connector_id": "GC1",
                 "start_time": evening_by_month.isoformat(),
                 "cost": {
@@ -375,7 +375,7 @@ if __name__ == '__main__':
                         help='Provide start time of simulation in ISO format '
                              'YYYY-MM-DDTHH:MM:SS+TZ:TZ. Precision is 1 second. E.g. '
                              '2018-01-31T01:00:00+02:00')
-    parser.add_argument('--no-drive-day', default=6, type=int,
+    parser.add_argument('--no-drive-days', default=[6], type=int,
                         help='Provide weekday of vehicles not driving (default: Sunday)')
     parser.add_argument('--min-soc', metavar='SOC', type=float, default=0.8,
                         help='set minimum desired SOC (0 - 1) for each charging process')

--- a/generate.py
+++ b/generate.py
@@ -9,6 +9,7 @@ from os import path
 
 from src.util import set_options_from_config, datetime_from_isoformat
 
+
 DEFAULT_START_TIME = "2018-01-01T01:00:00+02:00"
 
 
@@ -32,10 +33,10 @@ def generate_trip(args):
     min_distance = vars(args).get("min_distance", 27.23)
     max_distance = vars(args).get("max_distance", 67.02)
     # departure time
-    avg_start = vars(args).get("avg_start", "18:15")  # hh:mm
+    avg_start = vars(args).get("avg_start", "08:15")  # hh:mm
     std_start = vars(args).get("std_start", 0.42)  # hours
-    min_start = vars(args).get("min_start", "17:00")
-    max_start = vars(args).get("max_start", "19:30")
+    min_start = vars(args).get("min_start", "07:00")
+    max_start = vars(args).get("max_start", "17:30")
     # trip duration
     avg_driving = vars(args).get("avg_driving", 8.33)  # hours
     std_driving = vars(args).get("std_driving", 1.35)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,7 +20,7 @@ ARG_VALUES1 = {
     "min_soc": 0.8,
     "battery": [[350, 0.5]],
     "start_time": '2018-01-01T00:15:00+00:00',
-    "no_drive_day": 6,
+    "no_drive_days": [6],
     "vehicle_types": "test_data/input_test_generate/vehicle_types.json",
     "include_ext_load_csv": None,
     "include_ext_csv_option": [],

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,6 +20,7 @@ ARG_VALUES1 = {
     "min_soc": 0.8,
     "battery": [[350, 0.5]],
     "start_time": '2018-01-01T00:15:00+00:00',
+    "no_drive_day": 6,
     "vehicle_types": "test_data/input_test_generate/vehicle_types.json",
     "include_ext_load_csv": None,
     "include_ext_csv_option": [],


### PR DESCRIPTION
Fix #80 

**Changes proposed in this pull request**:
- Fixed calculation of arrival time for the case that arrival is on next day.
- Set multiple no_drive_dates of vehicles via config file

The following steps were realized, as well (required):
- [x] Correct linting with `fake8 path_to_script`
- [x] Check if tests pass locally (`pytest ./src/tests.py`)

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [ ] Write test(s) for your new patch of code


*Please mark above checkboxes as following:*
- [ ] Open
- [x] Done
