### PR TITLE
stop tracking socs per GC

### DIFF
--- a/src/scenario.py
+++ b/src/scenario.py
@@ -645,7 +645,8 @@ class Scenario:
                 for idx, r in enumerate(results):
                     # general info: timestep index and timestamp
                     # TZ removed for spreadsheet software
-                    row_s = [idx, r['current_time'].replace(tzinfo=None)] + contiuous_soc[idx]
+                    row_s = [idx, r['current_time'].replace(tzinfo=None).isoformat()]
+                    row_s += contiuous_soc[idx]
 
                     # write row to file
                     soc_file.write('\n' + ','.join(map(lambda x: str(x), row_s)))


### PR DESCRIPTION
Fix #Issue

**Changes proposed in this pull request**:
- Collect the SOCs after each simulation step indepent of the grid connectors. The state of charge has nothing not tied to a grid connector in any way. 
- Fixes:
  - Calculation of disconnected SOCs for vehicles travelling from one GC to a another.
  - Different colors in graph for single vehicle for connected and disconnected timesteps.
  - Simplified procedure for "save_soc" option 

The following steps were realized, as well (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally (`pytest ./src/tests.py`)
