### PR TITLE
add strategy option RESET_NEGATIVE_SOC

### DIFF
--- a/doc/source/charging_strategies.rst
+++ b/doc/source/charging_strategies.rst
@@ -8,7 +8,7 @@ The core of SpiceEV are the different charging strategies. They decide how to re
 
 All charging strategies support the `EPS` option, which defines the difference under which two floating point numbers are considered equal. In other words, the value chosen for `EPS` determines the precision of the simulation. The smaller it is the more precise the calculations are. The downside to this is an increase running time. For some numerical procedures the algorithm might get stuck completely if `EPS` is too small. The default is 10^-5.
 
-Every strategy also supports the strategy option `allow_negative_soc`. This option sets negative SoCs to `0` and continues the simulation instead of aborting. The default value is `False`, setting it to `True` will activate the option. The option is passed in `strategy_option` list.
+Every strategy also supports the strategy option `ALLOW_NEGATIVE_SOC` and `RESET_NEGATIVE_SOC`. They control how to proceed should the SoC of a vehicle become negative. Both are False by default, which means the simulation will abort in such a case. If `ALLOW_NEGATIVE_SOC` is set, the simulation continues instead of aborting. If `RESET_NEGATIVE_SOC` is set, the SoC of the vehicle is set to zero. These options are helpful when simulating plug-in hybrids.
 
 Greedy
 ======
@@ -186,7 +186,7 @@ V2G supported: **YES**
     +----------------------+---------------+---------------------------------------------------------------------+
     |**Strategy option**   | **default**   |              **explanation**                                        |
     +----------------------+---------------+---------------------------------------------------------------------+
-    |   ALLOW_NEGATIVE_SOC |   True        | simulation does not abort if SoC becomes negative                   |
+    |   ALLOW_NEGATIVE_SOC |   False       | simulation does not abort if SoC becomes negative                   |
     +----------------------+---------------+---------------------------------------------------------------------+
     |   C-HORIZON          |      3        | loading time in min reserved for vehicle if number of cs is limited |
     +----------------------+---------------+---------------------------------------------------------------------+

--- a/doc/source/charging_strategies.rst
+++ b/doc/source/charging_strategies.rst
@@ -8,7 +8,7 @@ The core of SpiceEV are the different charging strategies. They decide how to re
 
 All charging strategies support the `EPS` option, which defines the difference under which two floating point numbers are considered equal. In other words, the value chosen for `EPS` determines the precision of the simulation. The smaller it is the more precise the calculations are. The downside to this is an increase running time. For some numerical procedures the algorithm might get stuck completely if `EPS` is too small. The default is 10^-5.
 
-Every strategy also supports the strategy option `ALLOW_NEGATIVE_SOC` and `RESET_NEGATIVE_SOC`. They control how to proceed should the SoC of a vehicle become negative. Both are False by default, which means the simulation will abort in such a case. If `ALLOW_NEGATIVE_SOC` is set, the simulation continues instead of aborting. If `RESET_NEGATIVE_SOC` is set, the SoC of the vehicle is set to zero. These options are helpful when simulating plug-in hybrids.
+Every strategy also supports the strategy options `ALLOW_NEGATIVE_SOC` and `RESET_NEGATIVE_SOC`. They control how to proceed should the SoC of a vehicle become negative. Both are False by default, which means the simulation will abort in such a case. If `ALLOW_NEGATIVE_SOC` is set, the simulation continues instead of aborting. If `RESET_NEGATIVE_SOC` is set, the SoC of the vehicle is set to zero. These options are helpful when simulating plug-in hybrids.
 
 Greedy
 ======

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -118,15 +118,11 @@ class Strategy():
                     # vehicle leaves: disconnect vehicle
                     vehicle.connected_charging_station = None
                     # check that vehicle has charged enough
-                    if vehicle.battery.soc < (1-self.margin)*vehicle.desired_soc - self.EPS:
-                        # not charged enough: warn or stop simulation completely
-                        msg = "{}: Vehicle {} is below desired SOC ({} < {})".format(
+                    if 0 <= vehicle.battery.soc < (1-self.margin)*vehicle.desired_soc - self.EPS:
+                        # not charged enough: stop simulation
+                        raise RuntimeError("{}: Vehicle {} is below desired SOC ({} < {})".format(
                             ev.start_time.isoformat(), ev.vehicle_id,
-                            vehicle.battery.soc, vehicle.desired_soc)
-                        if vehicle.battery.soc < 0 and self.ALLOW_NEGATIVE_SOC:
-                            warn(msg)
-                        else:
-                            raise RuntimeError(msg)
+                            vehicle.battery.soc, vehicle.desired_soc))
                 elif ev.event_type == "arrival":
                     # vehicle arrives
                     assert hasattr(vehicle, 'soc_delta')

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -37,6 +37,7 @@ class Strategy():
         # relative allowed difference between battery SoC and desired SoC when leaving
         self.margin = 0.1
         self.ALLOW_NEGATIVE_SOC = False
+        self.RESET_NEGATIVE_SOC = False
         self.V2G_POWER_FACTOR = 0.5
         # check if strategy uses grid signals & enable/disable plotting of schedule or window
         self.uses_schedule = False
@@ -110,30 +111,40 @@ class Strategy():
 
             elif type(ev) == events.VehicleEvent:
                 vehicle = self.world_state.vehicles[ev.vehicle_id]
+                # update vehicle attributes
                 for k, v in ev.update.items():
                     setattr(vehicle, k, v)
                 if ev.event_type == "departure":
+                    # vehicle leaves: disconnect vehicle
                     vehicle.connected_charging_station = None
-                    assert vehicle.battery.soc >= (1-self.margin)*vehicle.desired_soc - self.EPS, (
-                        "{}: Vehicle {} is below desired SOC ({} < {})".format(
+                    # check that vehicle has charged enough
+                    if vehicle.battery.soc < (1-self.margin)*vehicle.desired_soc - self.EPS:
+                        # not charged enough: warn or stop simulation completely
+                        msg = "{}: Vehicle {} is below desired SOC ({} < {})".format(
                             ev.start_time.isoformat(), ev.vehicle_id,
-                            vehicle.battery.soc, vehicle.desired_soc))
-
+                            vehicle.battery.soc, vehicle.desired_soc)
+                        if self.ALLOW_NEGATIVE_SOC:
+                            warn(msg)
+                        else:
+                            raise RuntimeError(msg)
                 elif ev.event_type == "arrival":
+                    # vehicle arrives
                     assert hasattr(vehicle, 'soc_delta')
+                    # soc_delta always negative
                     vehicle.battery.soc += vehicle.soc_delta
                     if vehicle.battery.soc + self.EPS < 0:
+                        # vehicle was not charged enough to make trip
                         if ev.vehicle_id not in self.negative_soc_tracker.keys():
                             self.negative_soc_tracker.update({ev.vehicle_id:
                                                               self.current_time.isoformat()})
                         if self.ALLOW_NEGATIVE_SOC:
-                            warn('SOC of vehicle {} became negative at {}. SOC is {}, '
-                                 'continuing with SOC = 0'
+                            warn('SOC of vehicle {} became negative at {}. SOC is {}'
                                  .format(ev.vehicle_id, self.current_time, vehicle.battery.soc),
                                  # settings stack level high to avoid confusing
                                  # info about origin of error (e.g. filename, lineno)
                                  stacklevel=100)
-                            vehicle.battery.soc = 0
+                            if self.RESET_NEGATIVE_SOC:
+                                vehicle.battery.soc = 0
                         else:
                             raise RuntimeError(
                                 'SOC of vehicle {} should not be negative. '

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -123,7 +123,7 @@ class Strategy():
                         msg = "{}: Vehicle {} is below desired SOC ({} < {})".format(
                             ev.start_time.isoformat(), ev.vehicle_id,
                             vehicle.battery.soc, vehicle.desired_soc)
-                        if self.ALLOW_NEGATIVE_SOC:
+                        if vehicle.battery.soc < 0 and self.ALLOW_NEGATIVE_SOC:
                             warn(msg)
                         else:
                             raise RuntimeError(msg)


### PR DESCRIPTION
Separates functionality of `ALLOW_NEGATIVE_SOC`. Now it is possible to proceed with negative SoC.