### PR TITLE
restructure scenario intervals

### DIFF
--- a/src/report.py
+++ b/src/report.py
@@ -493,7 +493,7 @@ def save_soc_timeseries(scenario, output_path):
         if ext != ".csv":
             print("File extension mismatch: timeseries file is of type .csv")
 
-        with open(output_path, "w+") as soc_file:
+        with open(output_path, "w") as soc_file:
             # write header
             header_s = ["timestep", "time"]
             for vidx, vid in enumerate(sorted(scenario.constants.vehicles.keys())):
@@ -545,7 +545,7 @@ def plot(scenario):
     ax = plt.subplot(2, plots_top_row, 1)
     ax.set_title('Vehicles')
     ax.set(ylabel='SoC')
-    lines = ax.step(xlabels, scenario.socs)
+    lines = ax.plot(xlabels, scenario.socs)
     # reset color cycle, so lines have same color
     ax.set_prop_cycle(None)
 
@@ -557,31 +557,31 @@ def plot(scenario):
     ax = plt.subplot(2, plots_top_row, 2)
     ax.set_title('Charging Stations')
     ax.set(ylabel='Power in kW')
-    lines = ax.step(xlabels, scenario.sum_cs)
+    lines = ax.step(xlabels, scenario.sum_cs, where='post')
     if len(scenario.constants.charging_stations) <= 10:
         ax.legend(lines, sorted(scenario.constants.charging_stations.keys()))
 
     # total power
     ax = plt.subplot(2, 2, 3)
-    ax.plot(xlabels, list([sum(cs) for cs in scenario.sum_cs]), label="CS")
+    ax.step(xlabels, list([sum(cs) for cs in scenario.sum_cs]), label="CS", where='post')
     gc_ids = scenario.constants.grid_connectors.keys()
     for gcID in gc_ids:
         for name, values in scenario.loads[gcID].items():
-            ax.plot(xlabels, values, label=name)
+            ax.step(xlabels, values, label=name, where='post')
     # draw schedule
     if scenario.strat.uses_window:
         for gcID, schedule in scenario.gcWindowSchedule.items():
             if all(s is not None for s in schedule):
                 # schedule exists
                 window_values = [v * int(max(scenario.totalLoad[gcID])) for v in schedule]
-                ax.plot(xlabels, window_values, label="window {}".format(gcID),
-                        linestyle='--')
+                ax.step(xlabels, window_values, label="window {}".format(gcID),
+                        linestyle='--', where='post')
     if scenario.strat.uses_schedule:
         for gcID, schedule in scenario.gcPowerSchedule.items():
             if any(s is not None for s in schedule):
-                ax.plot(xlabels, schedule, label="Schedule {}".format(gcID))
+                ax.step(xlabels, schedule, label="Schedule {}".format(gcID), where='post')
 
-    ax.plot(xlabels, scenario.all_totalLoad, label="Total")
+    ax.step(xlabels, scenario.all_totalLoad, label="Total", where='post')
     ax.set_title('Power')
     ax.set(ylabel='Power in kW')
     ax.legend()
@@ -590,7 +590,7 @@ def plot(scenario):
     # price
     ax = plt.subplot(2, 2, 4)
     prices = list(zip(*scenario.prices.values()))
-    lines = ax.step(xlabels, prices)
+    lines = ax.step(xlabels, prices, where='post')
     ax.set_title('Price for 1 kWh')
     ax.set(ylabel='€')
     if len(gc_ids) <= 10:

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -170,11 +170,13 @@ class Scenario:
                 batteryLevels[batName].append(bat.soc * bat.capacity)
 
             # run strategy for single timestep
+            # default: no action
+            res = {'current_time': strat.current_time, 'commands': {}}
             try:
-                res = strat.step()
+                if error is None:
+                    res = strat.step()
             except Exception:
                 # error during strategy: add dummy result and abort
-                res = {'current_time': strat.current_time, 'commands': {}}
                 error = traceback.format_exc()
             results.append(res)
 

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -85,9 +85,11 @@ class Scenario:
         connChargeByTS = {gcID: [] for gcID in gc_ids}
         gcPowerSchedule = {gcID: [] for gcID in gc_ids}
         gcWindowSchedule = {gcID: [] for gcID in gc_ids}
+        departed_vehicles = {}
         gcWithinPowerLimit = True
 
         begin = datetime.datetime.now()
+        error = None
         for step_i in range(self.n_intervals):
 
             if options.get("timing", False):
@@ -116,21 +118,13 @@ class Scenario:
                         '.' * (width - progress)
                     ), end="", flush=True)
 
-            # run single timestep
+            # process events
             try:
-                res = strat.step(event_steps[step_i])
-            except Exception as e:
-                print('\n', '*'*42)
-                print(e)
-                print("Aborting simulation in timestep {} ({})".format(
-                    step_i + 1, strat.current_time))
-                strat.description = "*** {} (ABORTED) ***".format(strat.description)
-                traceback.print_exc()
-                step_i -= 1
-                break
-            results.append(res)
+                super(type(strat), strat).step(event_steps[step_i])
+            except Exception:
+                error = traceback.format_exc()
 
-            # get SOC for all vehicle at all timesteps
+            # get vehicle SoC at start of timestep
             cur_dis = []
             cur_socs = []
             for vidx, vid in enumerate(sorted(strat.world_state.vehicles.keys())):
@@ -138,39 +132,53 @@ class Scenario:
                 cur_socs.append(None)
                 cur_dis.append(None)
                 connected = vehicle.connected_charging_station is not None
-                departing = (vehicle.estimated_time_of_departure is not None
-                             and vehicle.estimated_time_of_departure > strat.current_time)
-                if connected or departing:
-                    # not driving
-                    if connected:
-                        # connected: save soc
-                        cur_socs[-1] = vehicle.battery.soc
+                departed = (vehicle.estimated_time_of_departure is None
+                            or vehicle.estimated_time_of_departure <= strat.current_time)
+
+                if connected:
+                    cur_socs[-1] = vehicle.battery.soc
+                else:
+                    if departed:
+                        if vid not in departed_vehicles:
+                            # newly departed: save current soc, make note of departure
+                            cur_dis[-1] = vehicle.battery.soc
+                            departed_vehicles[vid] = (step_i, vehicle.battery.soc)
+                            # just for continuous lines in plot between connected and disconnected
+                            if step_i > 0 and socs[-1][vidx] is not None:
+                                cur_socs[-1] = vehicle.battery.soc
                     else:
-                        # not connected, just standing
+                        # not driving,just standing disconnected
                         cur_dis[-1] = vehicle.battery.soc
-                    if step_i > 0 and socs[-1][vidx] is None and disconnect[-1][vidx] is None:
-                        # just arrived -> update disconnect
-                        # find last known soc
-                        start_idx = step_i-1
-                        while (
-                                start_idx >= 0 and
-                                socs[start_idx][vidx] is None and
-                                disconnect[start_idx][vidx] is None):
-                            start_idx -= 1
-                        if start_idx < 0:
-                            # first charge, no info about old soc
-                            continue
-                        # get start soc
-                        start_soc = socs[start_idx][vidx] or disconnect[start_idx][vidx] or 0
-                        # compute linear equation
-                        m = (vehicle.battery.soc - start_soc) / (step_i - start_idx)
-                        # update timesteps between start and now
-                        for idx in range(start_idx, step_i):
-                            disconnect[idx][vidx] = m * (idx - start_idx) + start_soc
+
+                if (connected or not departed) and vid in departed_vehicles:
+                    # newly arrived: update disconnect with linear interpolation
+                    start_idx, start_soc = departed_vehicles[vid]
+                    # compute linear equation
+                    m = (vehicle.battery.soc - start_soc) / (step_i - start_idx)
+                    # update timesteps between start and now
+                    for idx in range(start_idx, step_i):
+                        disconnect[idx][vidx] = m * (idx - start_idx) + start_soc
+                        cur_dis[-1] = vehicle.battery.soc
+                    # remove vehicle from departed list
+                    del departed_vehicles[vid]
 
             socs.append(cur_socs)
             disconnect.append(cur_dis)
 
+            # get battery levels at start of timestep
+            for batName, bat in strat.world_state.batteries.items():
+                batteryLevels[batName].append(bat.soc * bat.capacity)
+
+            # run strategy for single timestep
+            try:
+                res = strat.step()
+            except Exception:
+                # error during strategy: add dummy result and abort
+                res = {'current_time': strat.current_time, 'commands': {}}
+                error = traceback.format_exc()
+            results.append(res)
+
+            # get loads during timestep
             for gcID, gc in strat.world_state.grid_connectors.items():
 
                 # get current loads
@@ -195,10 +203,12 @@ class Scenario:
 
                 # safety check: GC load within bounds?
                 gcWithinPowerLimit &= -gc.max_power-strat.EPS <= gc_load <= gc.max_power+strat.EPS
-                if not gcWithinPowerLimit:
-                    print('\n', '*'*42)
-                    print("{} maximum load exceeded: {} / {}".format(gcID, gc_load, gc.max_power))
-                    strat.description = "*** {} (ABORTED) ***".format(strat.description)
+                try:
+                    assert gcWithinPowerLimit, (
+                        "{} maximum load exceeded: {} / {}".format(gcID, gc_load, gc.max_power))
+                except AssertionError:
+                    # abort if GC power limit exceeded
+                    error = traceback.format_exc()
 
                 # compute cost: price in ct/kWh -> get price in EUR
                 if gc.cost:
@@ -228,18 +238,15 @@ class Scenario:
                 feedInPower[gcID].append(curFeedIn)
                 connChargeByTS[gcID].append(cur_cs)
 
-            # get battery levels
-            for batName, bat in strat.world_state.batteries.items():
-                batteryLevels[batName].append(bat.soc * bat.capacity)
-
-            # abort if GC power limit exceeded
-            if not gcWithinPowerLimit:
+            if error is not None:
+                print('\n', '*'*42)
+                print("Aborting simulation in timestep {} ({})".format(
+                    step_i + 1, strat.current_time))
+                strat.description = "*** {} (ABORTED) ***".format(strat.description)
+                print(error)
                 break
 
         # next simulation timestep
-
-        # adjust step_i: n_intervals or failed simulation step
-        step_i += 1
 
         # make variable members of Scenario class to access them in report
         for var in ["socs", "strat", "costs", "step_i", "prices", "results", "extLoads",

--- a/src/strategies/balanced.py
+++ b/src/strategies/balanced.py
@@ -16,7 +16,7 @@ class Balanced(Strategy):
         super().__init__(constants, start_time, **kwargs)
         self.description = "balanced"
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
         :param event_list: List of events
@@ -24,7 +24,6 @@ class Balanced(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         # get power that can be drawn from battery in this timestep
         avail_bat_power = {}

--- a/src/strategies/balanced.py
+++ b/src/strategies/balanced.py
@@ -19,8 +19,7 @@ class Balanced(Strategy):
     def step(self):
         """
         Calculates charging in each timestep.
-        :param event_list: List of events
-        :type event_list: list
+
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/balanced_market.py
+++ b/src/strategies/balanced_market.py
@@ -31,7 +31,7 @@ class BalancedMarket(Strategy):
         if changed:
             print(changed, "events signaled earlier")
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
 
@@ -40,7 +40,6 @@ class BalancedMarket(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         gc = list(self.world_state.grid_connectors.values())[0]
 

--- a/src/strategies/balanced_market.py
+++ b/src/strategies/balanced_market.py
@@ -35,8 +35,6 @@ class BalancedMarket(Strategy):
         """
         Calculates charging in each timestep.
 
-        :param event_list: List of events
-        :type event_list: list
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/distributed.py
+++ b/src/strategies/distributed.py
@@ -20,8 +20,7 @@ class Distributed(Strategy):
         # dict that holds the current vehicles connected to a grid connector for each gc
         self.v_connect = {gcID: [] for gcID in self.world_state.grid_connectors.keys()}
 
-    def step(self, event_list=[]):
-        super().step(event_list)
+    def step(self):
 
         # get power that can be drawn from battery in this timestep
         avail_bat_power = {}

--- a/src/strategies/flex_window.py
+++ b/src/strategies/flex_window.py
@@ -41,8 +41,6 @@ class FlexWindow(Strategy):
         """
         Calculates charging in each timestep.
 
-        :param event_list: List of events
-        :type event_list: list
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/flex_window.py
+++ b/src/strategies/flex_window.py
@@ -37,7 +37,7 @@ class FlexWindow(Strategy):
         else:
             "Unknown charging strategy: {}".format(self.LOAD_STRAT)
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
 
@@ -46,7 +46,6 @@ class FlexWindow(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         gc = list(self.world_state.grid_connectors.values())[0]
 

--- a/src/strategies/greedy.py
+++ b/src/strategies/greedy.py
@@ -19,8 +19,7 @@ class Greedy(Strategy):
     def step(self):
         """
         Calculates charging in each timestep.
-        :param event_list: List of events
-        :type event_list: list
+
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/greedy.py
+++ b/src/strategies/greedy.py
@@ -16,7 +16,7 @@ class Greedy(Strategy):
         super().__init__(constants, start_time, **kwargs)
         self.description = "greedy"
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
         :param event_list: List of events
@@ -24,7 +24,6 @@ class Greedy(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         # get power that can be drawn from battery in this timestep at each grid connector
         avail_bat_power = {}

--- a/src/strategies/greedy_market.py
+++ b/src/strategies/greedy_market.py
@@ -31,7 +31,7 @@ class GreedyMarket(Strategy):
         if changed:
             print(changed, "events signaled earlier")
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
 
@@ -40,7 +40,6 @@ class GreedyMarket(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         gc = list(self.world_state.grid_connectors.values())[0]
 

--- a/src/strategies/greedy_market.py
+++ b/src/strategies/greedy_market.py
@@ -35,8 +35,6 @@ class GreedyMarket(Strategy):
         """
         Calculates charging in each timestep.
 
-        :param event_list: List of events
-        :type event_list: list
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/peak_load_window.py
+++ b/src/strategies/peak_load_window.py
@@ -62,8 +62,6 @@ class PeakLoadWindow(Strategy):
         """
         Calculates charging in each timestep.
 
-        :param event_list: List of events
-        :type event_list: list
         :return: current time and commands of the charging stations
         :rtype: dict
         """

--- a/src/strategies/peak_load_window.py
+++ b/src/strategies/peak_load_window.py
@@ -58,7 +58,7 @@ class PeakLoadWindow(Strategy):
 
         assert len(self.world_state.grid_connectors) == 1, "Only one grid connector supported"
 
-    def step(self, event_list=[]):
+    def step(self):
         """
         Calculates charging in each timestep.
 
@@ -67,7 +67,6 @@ class PeakLoadWindow(Strategy):
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         timesteps_per_day = datetime.timedelta(days=1) // self.interval
         timesteps_per_hour = datetime.timedelta(hours=1) / self.interval

--- a/src/strategies/schedule.py
+++ b/src/strategies/schedule.py
@@ -733,15 +733,12 @@ class Schedule(Strategy):
                 bat_power = 0
             gc.add_load(bid, bat_power)
 
-    def step(self, event_list=[]):
+    def step(self):
         """Calculates charging in each timestep.
 
-        :param event_list: List of events
-        :type event_list: list
         :return: current time and commands of the charging stations
         :rtype: dict
         """
-        super().step(event_list)
 
         # no car is charging at beginning of TS
         for cs in self.world_state.charging_stations.values():

--- a/src/strategies/schedule_foresight.py
+++ b/src/strategies/schedule_foresight.py
@@ -35,8 +35,7 @@ class ScheduleForesight(Strategy):
 
         assert len(self.world_state.grid_connectors) == 1, "Only one grid connector supported"
 
-    def step(self, event_list=[]):
-        super().step(event_list)
+    def step(self):
 
         gc = list(self.world_state.grid_connectors.values())[0]
 

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -122,6 +122,7 @@ class Strategy():
                 for k, v in ev.update.items():
                     setattr(vehicle, k, v)
                 if ev.event_type == "departure":
+                    vehicle.estimated_time_of_departure = None
                     if ev.start_time < self.current_time - self.interval:
                         # event from the past: simulate optimal charging
                         vehicle.battery.soc = vehicle.desired_soc

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -178,11 +178,11 @@ class TestScenarios(TestCaseBase):
         assert s.testing["avg_total_standing_time"]["GC1"] == 17.5
         assert s.testing["avg_stand_time"]["GC1"] == 8.75
         assert round(s.testing["avg_needed_energy"]["GC1"], 2) == 1.08
-        assert round(s.testing["avg_drawn_power"]["GC1"], 2) == 1.44
+        assert round(s.testing["avg_drawn_power"]["GC1"], 2) == 1.45
         assert round(s.testing["sum_feed_in_per_h"]["GC1"], 2) == 0
         assert round(s.testing["vehicle_battery_cycles"]["GC1"], 2) == 1.1
         assert round(s.testing["avg_flex_per_window"]["GC1"][0], 2) == 372
-        assert round(s.testing["avg_flex_per_window"]["GC1"][3], 2) == 375.71
+        assert round(s.testing["avg_flex_per_window"]["GC1"][3], 2) == 375.39
         assert round(s.testing["sum_energy_per_window"]["GC1"][0], 2) == 0
         assert round(s.testing["sum_energy_per_window"]["GC1"][3], 2) == 0
         load = [0] * 96


### PR DESCRIPTION
- more intuitive relation between timestamp and SoC/power/energy.
  - SoC of vehicles and batteries are measured at the start of the interval (was taken at end of interval before)
  - power/energy is meant for ongoing interval
  - in case of strategy/event error, current interval is finished gracefully
- super-Strategy.step function called from scenario, not from strategy. This also means a strategy does not need current events anymore (removed event_list argument from specific strategy step)
- no problem for plotting if vehicle has wrong estimated_time_of_departure (reset when departing)
- plotting: SoC (vehicles, batteries) are line plots, power (CS, total) are step plots
- open timeseries file in write mode instead of RW