### PR TITLE
add loss rate to batteries

### DIFF
--- a/examples/vehicle_types.json
+++ b/examples/vehicle_types.json
@@ -48,6 +48,11 @@
         "min_charging_power": 0,
         "v2g": false,
         "v2g_power_factor": 0.5,
-        "battery_efficiency": 0.95
+        "battery_efficiency": 0.95,
+        "loss_rate": {
+            "relative": 0,
+            "fixed_relative": 0,
+            "fixed_absolute": 0
+        }
     }
 }

--- a/src/battery.py
+++ b/src/battery.py
@@ -6,20 +6,27 @@ from src.loading_curve import LoadingCurve
 
 class Battery():
     """Battery class"""
-    def __init__(self, capacity, loading_curve, soc, efficiency=0.95, unloading_curve=None):
-        """ Initializing the battery
-        :param capacity: capacity of the battery
-        :type capacity: int/float
+    def __init__(self, capacity, loading_curve, soc,
+                 efficiency=0.95, unloading_curve=None, loss_rate=None):
+        """ Initialize the battery.
+
+        :param capacity: capacity of the battery in kWh
+        :type capacity: numerical
         :param loading_curve: loading curve of the battery
         :type loading_curve: src.loading_curve.LoadingCurve
         :param soc: soc of the battery
         :type soc: float
         :param efficiency: efficiency of the battery
         :type efficiency: float
-        :param unloading_curve: unloading curve of the battery
-            defaults to None for backwards-compatability, discharge with maximum
-            power of loading curve in case no unloading curve specified
+        :param unloading_curve: unloading curve of the battery.
+            Defaults to None for backwards-compatability (discharge with maximum
+            power of loading curve)
         :type unloading_curve: src.loading_curve.LoadingCurve
+        :param loss_rate: adjusted loss rate per timestep. Can have keys
+            *relative* (percent in relation to current charge),
+            *fixed_relative* (percent in relation to capacity) and
+            *fixed_absolute* (energy in kWh independent of capacity)
+        :type loss_rate: dict
         """
         # epsilon for floating point comparison
         self.EPS = 1e-5
@@ -27,6 +34,7 @@ class Battery():
         self.loading_curve = copy.deepcopy(loading_curve)
         self.soc = soc
         self.efficiency = efficiency
+        self.loss_rate = loss_rate
         if unloading_curve is None:
             self.unloading_curve = LoadingCurve([[0, self.loading_curve.max_power],
                                                  [1, self.loading_curve.max_power]])

--- a/src/constants.py
+++ b/src/constants.py
@@ -163,7 +163,8 @@ class VehicleType:
             ('battery_efficiency', float, 0.95),
             ('v2g', bool, False),
             ('v2g_power_factor', float, 0.5),
-            ('discharge_curve', loading_curve.LoadingCurve, None)
+            ('discharge_curve', loading_curve.LoadingCurve, None),
+            ('loss_rate', float, 0),
         ]
         util.set_attr_from_dict(obj, self, keys, optional_keys)
 
@@ -193,6 +194,7 @@ class Vehicle:
             soc=self.soc,
             efficiency=self.vehicle_type.battery_efficiency,
             unloading_curve=self.vehicle_type.discharge_curve,
+            loss_rate=self.vehicle_type.loss_rate,
         )
         del self.soc
 
@@ -228,7 +230,8 @@ class StationaryBattery(battery.Battery):
             ('min_charging_power', float, 0.0),
             ('soc', float, 0.0),
             ('efficiency', float, 0.95),
-            ('discharge_curve', loading_curve.LoadingCurve, None)
+            ('discharge_curve', loading_curve.LoadingCurve, None),
+            ('loss_rate', float, 0),
         ]
         util.set_attr_from_dict(obj, self, keys, optional_keys)
         assert self.min_charging_power <= self.charging_curve.max_power
@@ -240,4 +243,5 @@ class StationaryBattery(battery.Battery):
             self.soc,
             self.efficiency,
             self.discharge_curve,
+            self.loss_rate,
         )

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -180,6 +180,9 @@ class Scenario:
                 error = traceback.format_exc()
             results.append(res)
 
+            # apply battery losses at end of timestep
+            strat.apply_battery_losses()
+
             # get loads during timestep
             for gcID, gc in strat.world_state.grid_connectors.items():
 

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -245,3 +245,20 @@ class Strategy():
                 # GC draws power: use stored energy to support GC
                 bat_power = battery.unload(self.interval, gc_current_load)['avg_power']
                 gc.add_load(b_id, -bat_power)
+
+    def apply_battery_losses(self):
+        """
+        Regardless of specific strategy, reduce SoC of lossy batteries. In-place.
+        """
+        for battery in (
+                        list(self.world_state.batteries.values()) +
+                        [v.battery for v in self.world_state.vehicles.values()]):
+            if battery.loss_rate:
+                relative_loss = battery.loss_rate.get("relative", 0)
+                battery.soc *= 1 - relative_loss/100
+                fixed_relative_loss = battery.loss_rate.get("fixed_relative", 0)
+                battery.soc -= fixed_relative_loss / 100
+                fixed_absolute_loss = battery.loss_rate.get("fixed_absolute", 0)
+                battery.soc -= fixed_absolute_loss / battery.capacity
+                # can only discharge, but not become negative
+                battery.soc = max(battery.soc, 0)


### PR DESCRIPTION
All batteries (vehicle and stationary) can have a loss rate. This is a dictionary with the following possible keys:
relative: percentage lost per timestep in relation to the current charge
fixed_relative: percentage lost per timestep in relation to maximum capacity
fixed_absolute: flat amount of energy lost per timestep

Consider a battery with a capacity of 20 kWh and a state of charge (SoC) of 50%.
With a _relative_ loss rate of 10%, the SoC will be 45%.
With a _fixed_relative_ loss rate of 10%, the SoC will be 40%.
With a _fixed_absolute_ loss rate of 10 kWh, the SoC will be 0%.

Empty batteries do not empty further, the minimum is 0% SoC. Batteries that were below 0% will magically "fill" to 0%.

By default, the loss rate is disabled.