### PR TITLE
individual no_drive_days for each vehicle_type

### DIFF
--- a/examples/generate.cfg
+++ b/examples/generate.cfg
@@ -22,8 +22,6 @@ interval = 15
 min_soc = 0.8
 # set buffer of 10% on top of needed SoC for next trip
 # buffer = 0.1
-# set weekday of vehicles not driving (Monday = 0, Sunday = 6)
-no_drive_days = [6]
 # specify dates in ISO format of no driving
 holidays = ["2018-01-01"]
 # to set capability of V2G (default: false): change vehicle_types.json

--- a/examples/vehicle_types.json
+++ b/examples/vehicle_types.json
@@ -26,7 +26,8 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [5, 6]
     },
     "sprinter": {
         "name": "Sprinter",
@@ -55,7 +56,8 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [5, 6]
     },
     "golf": {
         "name": "E-Golf",
@@ -84,7 +86,8 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [2]
     },
     "AB-OPP": {
         "name": "articulated bus - opportunity charging",

--- a/generate.py
+++ b/generate.py
@@ -244,7 +244,7 @@ def generate(args):
     trips_above_min_soc = 0
     trips_total = 0
 
-    # create vehicle and price events
+    # create daily vehicle and price events
     daily = datetime.timedelta(days=1)
     now = start - daily
     while now < stop + 2 * daily:
@@ -252,8 +252,13 @@ def generate(args):
 
         # create vehicle events for this day
         for v_id, v in vehicles.items():
-            if now.weekday() in args.no_drive_days:
-                break
+            # check if day is defined as a no driving day for this vehicle_type
+            try:
+                if now.weekday() in vehicle_types[v["vehicle_type"]]["no_drive_days"]:
+                    break
+            except KeyError:
+                raise SystemExit(f"List of 'no_drive_days' missing for vehicle type "
+                                 f"'{v['vehicle_type']}'. Set in json of vehicle_types.")
             if now.date().isoformat() in vars(args).get("holidays", []):
                 break
 

--- a/generate.py
+++ b/generate.py
@@ -254,7 +254,7 @@ def generate(args):
         for v_id, v in vehicles.items():
             # check if day is defined as a no driving day for this vehicle_type
             try:
-                if now.weekday() in vehicle_types[v["vehicle_type"]]["no_drive_days"]:
+                if now.weekday() in vehicle_types[v["vehicle_type"]].get("no_drive_days", []):
                     break
             except KeyError:
                 raise SystemExit(f"List of 'no_drive_days' missing for vehicle type "

--- a/tests/test_data/input_test_generate/vehicle_types.json
+++ b/tests/test_data/input_test_generate/vehicle_types.json
@@ -25,7 +25,8 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [6]
     },
     "golf": {
         "name": "E-Golf",
@@ -53,7 +54,8 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [5, 6]
     },
     "AB-OPP": {
         "name": "articulated bus - opportunity charging",
@@ -81,6 +83,7 @@
                 "min_driving": 4.28,
                 "max_driving": 12.38
             }
-        }
+        },
+        "no_drive_days": [2]
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request**:
- removed no_drive_days from cfg file
- added no_drive_days to examples/vehicle_types and tests/test_data/input_test_generate/vehicle_types
- added error message if list of no_drive_days is not provided

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] For new functionalities: Explain in readthedocs
- [x] Write test(s) for your new patch of code
