### PR TITLE
set default est. time of dep. to end of sim instead of 8h

### DIFF
--- a/src/generate/generate_from_csv.py
+++ b/src/generate/generate_from_csv.py
@@ -42,6 +42,15 @@ def generate_from_csv(args):
     # read csv input file
     input = csv_to_dict(args.input_file)
 
+    # save path and options for CSV timeseries
+    times = []
+    for row in input:
+        times.append(row["departure_time"])
+    times.sort()
+    start = times[0]
+    start = datetime.datetime.strptime(start, DATETIME_FORMAT)
+    stop = start + datetime.timedelta(days=args.days)
+
     # INITIALIZE CONSTANTS AND EVENTS
     vehicle_types = {}
     vehicles = {}
@@ -128,8 +137,9 @@ def generate_from_csv(args):
                 next_arrival = v_id_list[idx + 1]["arrival_time"]
                 next_arrival = datetime.datetime.strptime(next_arrival, DATETIME_FORMAT)
             except IndexError:
+                # no departure event: stand until end of simulation
                 departure_event_in_input = False
-                departure = arrival + datetime.timedelta(hours=8)
+                departure = stop
 
             # check if column delta_soc or column soc exists
             if "delta_soc" not in row.keys():
@@ -227,15 +237,6 @@ def generate_from_csv(args):
                         }
                     })
 
-    # save path and options for CSV timeseries
-    times = []
-    for row in input:
-        times.append(row["departure_time"])
-    times.sort()
-    start = times[0]
-    start = datetime.datetime.strptime(start, DATETIME_FORMAT)
-    stop = start + datetime.timedelta(days=args.days)
-
     # update info of external CSV files
     ext_info = {
         "external_load": "include_ext_load_csv",
@@ -296,7 +297,7 @@ def generate_from_csv(args):
         "scenario": {
             "start_time": start.isoformat(),
             "interval": interval.total_seconds() // 60,
-            "n_intervals": (stop - start) // interval,
+            "n_intervals": stop.isoformat(),
             "discharge_limit": args.discharge_limit,
         },
         "constants": {

--- a/src/generate/generate_from_csv.py
+++ b/src/generate/generate_from_csv.py
@@ -139,7 +139,7 @@ def generate_from_csv(args):
             except IndexError:
                 # no departure event: stand until end of simulation
                 departure_event_in_input = False
-                departure = stop
+                departure = max(arrival + datetime.timedelta(hours=8), stop)
 
             # check if column delta_soc or column soc exists
             if "delta_soc" not in row.keys():

--- a/src/generate/generate_from_csv.py
+++ b/src/generate/generate_from_csv.py
@@ -297,7 +297,7 @@ def generate_from_csv(args):
         "scenario": {
             "start_time": start.isoformat(),
             "interval": interval.total_seconds() // 60,
-            "n_intervals": stop.isoformat(),
+            "stop_time": stop.isoformat(),
             "discharge_limit": args.discharge_limit,
         },
         "constants": {

--- a/src/generate/generate_from_csv.py
+++ b/src/generate/generate_from_csv.py
@@ -137,7 +137,7 @@ def generate_from_csv(args):
                 next_arrival = v_id_list[idx + 1]["arrival_time"]
                 next_arrival = datetime.datetime.strptime(next_arrival, DATETIME_FORMAT)
             except IndexError:
-                # no departure event: stand until end of simulation
+                # no departure: stand for 8h or until end of simulation (whichever comes later)
                 departure_event_in_input = False
                 departure = max(arrival + datetime.timedelta(hours=8), stop)
 

--- a/src/generate/generate_from_statistics.py
+++ b/src/generate/generate_from_statistics.py
@@ -296,7 +296,7 @@ def generate_from_statistics(args):
         "scenario": {
             "start_time": start.isoformat(),
             "interval": interval.total_seconds() // 60,
-            "n_intervals": (stop - start) // interval,
+            "stop_time": stop.isoformat(),
             "discharge_limit": args.discharge_limit,
         },
         "constants": {


### PR DESCRIPTION
Estimated time of departure was fixed to 8h when no further trip was made. This caused problems when the scenario ran for more than 8h still. On the other hand, trips ending right before the end of scenario need an estimated time of departure suitably far into the future. Therefore, the estimated time of departure was changed to be the maximum between the end of the scenario and 8 hours after arrival.
Also, changed scenario definition to use stop_time instead of n_intervals (where the calculation used the stop_time).