### PR TITLE
util.set_args_from_cfg: check option values

### DIFF
--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    util.set_options_from_config(args, check=False, verbose=False)
+    util.set_options_from_config(args, check=parser, verbose=False)
 
     # load simulation results:
     with open(args.get_results, "r", newline="") as sj:

--- a/generate.py
+++ b/generate.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
                         help='set number of minutes for each timestep (Δt)')
     parser.add_argument('--min-soc', metavar='SOC', type=float, default=0.8,
                         help='set minimum desired SOC (0 - 1) for each charging process')
-    parser.add_argument('--battery', '-b', default=[], nargs=2, type=float, action='append',
+    parser.add_argument('--battery', '-b', default=[], nargs=2, action='append',
                         help='add battery with specified capacity in kWh and C-rate \
                         (-1 for variable capacity, second argument is fixed power))')
     parser.add_argument('--gc-power', type=int, default=100, help='set power at grid connection '
@@ -247,6 +247,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    set_options_from_config(args, check=True, verbose=args.verbose > 1)
+    set_options_from_config(args, check=parser, verbose=args.verbose > 1)
 
     generate(args)

--- a/generate_schedule.py
+++ b/generate_schedule.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
         # no core standing time provided, defaulted to None
         pass
 
-    util.set_options_from_config(args, check=True, verbose=False)
+    util.set_options_from_config(args, check=parser, verbose=False)
 
     missing = [arg for arg in ["scenario", "input"] if vars(args).get(arg) is None]
     if missing:

--- a/simulate.py
+++ b/simulate.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     parser.add_argument('--config', help='Use config file to set arguments')
     args = parser.parse_args()
 
-    set_options_from_config(args, check=True, verbose=False)
+    set_options_from_config(args, check=parser, verbose=False)
 
     if args.output:
         warnings.warn("output argument is deprecated, use save-timeseries instead",


### PR DESCRIPTION
When setting options from a configuration file, the values are now checked against the argument parser information (same as giving the values on the command line).

Example: in generate.py, the number of simulated days can be set in the `days` option, which is of type integer. Until now, values from a config file were taken as-is without checks, so `days = seven` did not cause an immediate error (only later when trying to read out the value), while not making much sense. With this fix, this will now raise an error when reading in a configuration file with faulty values.
Unknown options in a config file are no longer supported. Tests include checks for wrong type and wrong choice.