### PR TITLE
extend test coverage

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -78,20 +78,17 @@ def update_namespace(args):
     # external input CSV files
     csv_files = {
         "external load": {
-            "filename": args.include_ext_load_csv,
-            "options": "include_ext_load_csv_option",
+            "filename": "include_ext_load_csv",
             "default_step_duration_s": 900,  # 15 minutes
             "default_column": "energy",
         },
         "feed-in": {
-            "filename": args.include_feed_in_csv,
-            "options": "include_feed_in_csv_option",
+            "filename": "include_feed_in_csv",
             "default_step_duration_s": 3600,  # 60 minutes
             "default_column": "energy",
         },
         "price": {
-            "filename": args.include_price_csv,
-            "options": "include_price_csv_option",
+            "filename": "include_price_csv",
             "default_step_duration_s": 3600,  # 60 minutes
             "default_column": "price [ct/kWh]",
         },
@@ -100,22 +97,31 @@ def update_namespace(args):
     target_path = Path(args.output).parent
 
     for file_type, file_info in csv_files.items():
-        if file_info["filename"] is not None:
+        # iterate over input CSV file types
+        csv_file = vars(args).get(file_info["filename"])
+        # fixed pattern: _option suffix for each CSV file type can be given
+        option_name = file_info["filename"] + "_option"
+        csv_options = vars(args).get(option_name, [])
+        if csv_file is not None:
+            # prepare default options
             options = {
-                "csv_file": file_info["filename"],
+                "csv_file": csv_file,
                 "start_time": None,
                 "step_duration_s": file_info["default_step_duration_s"],
                 "grid_connector_id": "GC1",
                 "column": file_info["default_column"],
             }
-            for key, value in vars(args)[file_info["options"]]:
+            # update from options given in args
+            for key, value in csv_options:
                 if key == "step_duration_s":
+                    # only special key: step_duration is number, not string
                     value = int(value)
                 options[key] = value
-            vars(args)[file_info["options"]] = options
+            # update options in namespace
+            vars(args)[option_name] = options
 
             # check if CSV file exists
-            ext_csv_path = target_path.joinpath(file_info["filename"])
+            ext_csv_path = target_path.joinpath(csv_file)
             if not ext_csv_path.exists():
                 warnings.warn(f"{file_type} csv file '{ext_csv_path}' does not exist yet.")
             else:
@@ -125,8 +131,13 @@ def update_namespace(args):
                     if not options["column"] in reader.fieldnames:
                         warnings.warn(f"{file_type} csv file '{ext_csv_path} "
                                       f"has no column {options['column']}'.")
-        elif vars(args)[file_info["options"]]:
-            warnings.warn(f"CSV {file_type} has options, but no file")
+        else:
+            vars(args)[file_info["filename"]] = None
+            if csv_options:
+                # options without CSV file
+                warnings.warn(f"CSV {file_type} has options, but no file")
+            else:
+                vars(args)[option_name] = None
 
 
 def generate(args):
@@ -144,6 +155,7 @@ def generate(args):
         "simbev": ["simbev", "output"],
         "statistics": ["output"],
     }
+    args.mode = vars(args).get("mode", "statistics")
     missing = [arg for arg in required[args.mode] if vars(args).get(arg) is None]
     if missing:
         raise SystemExit("The following arguments are required: {}".format(", ".join(missing)))

--- a/spice_ev/report.py
+++ b/spice_ev/report.py
@@ -582,25 +582,28 @@ def plot(scenario):
     ax = plt.subplot(2, plots_top_row, 1)
     ax.set_title('Vehicles')
     ax.set(ylabel='SoC')
-    lines = ax.plot(xlabels, scenario.socs)
-    # reset color cycle, so lines have same color
-    ax.set_prop_cycle(None)
+    if any(scenario.socs):
+        lines = ax.plot(xlabels, scenario.socs)
+        # reset color cycle, so lines have same color
+        ax.set_prop_cycle(None)
 
-    ax.plot(xlabels, scenario.disconnect, '--')
-    if len(scenario.components.vehicles) <= 10:
-        ax.legend(lines, sorted(scenario.components.vehicles.keys()))
+        ax.plot(xlabels, scenario.disconnect, '--')
+        if len(scenario.components.vehicles) <= 10:
+            ax.legend(lines, sorted(scenario.components.vehicles.keys()))
 
     # charging stations
     ax = plt.subplot(2, plots_top_row, 2)
     ax.set_title('Charging Stations')
     ax.set(ylabel='Power in kW')
-    lines = ax.step(xlabels, scenario.sum_cs, where='post')
-    if len(scenario.components.charging_stations) <= 10:
-        ax.legend(lines, sorted(scenario.components.charging_stations.keys()))
+    if any(scenario.sum_cs):
+        lines = ax.step(xlabels, scenario.sum_cs, where='post')
+        if len(scenario.components.charging_stations) <= 10:
+            ax.legend(lines, sorted(scenario.components.charging_stations.keys()))
 
     # total power
     ax = plt.subplot(2, 2, 3)
-    ax.step(xlabels, list([sum(cs) for cs in scenario.sum_cs]), label="CS", where='post')
+    if any(scenario.sum_cs):
+        ax.step(xlabels, list([sum(cs) for cs in scenario.sum_cs]), label="CS", where='post')
     gc_ids = scenario.components.grid_connectors.keys()
     for gcID in gc_ids:
         for name, values in scenario.loads[gcID].items():

--- a/spice_ev/strategy.py
+++ b/spice_ev/strategy.py
@@ -35,6 +35,7 @@ class Strategy():
         self.current_time = start_time - self.interval
         # relative allowed difference between battery SoC and desired SoC when leaving
         self.margin = 0.1
+        self.PRICE_THRESHOLD = 0
         self.ALLOW_NEGATIVE_SOC = False
         self.RESET_NEGATIVE_SOC = False
         self.V2G_POWER_FACTOR = 0.5
@@ -110,10 +111,7 @@ class Strategy():
                     connector.window = ev.window
                 # set max power from event
                 if connector.max_power:
-                    if ev.max_power is None:
-                        # event max power not set: reset to connector power
-                        connector.cur_max_power = connector.max_power
-                    else:
+                    if ev.max_power is not None:
                         connector.cur_max_power = min(connector.max_power, ev.max_power)
                 else:
                     # connector max power not set

--- a/tests/test_data/input_test_strategies/scenario_PV_Bat.json
+++ b/tests/test_data/input_test_strategies/scenario_PV_Bat.json
@@ -26,7 +26,7 @@
           ]
         ],
         "min_charging_power": 0.2,
-        "v2g": false,
+        "v2g": true,
         "v2g_power_factor": 0.5
       }
     },

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 import json
 from pathlib import Path
 import pytest
+import warnings
 
 from generate import generate
 from spice_ev import scenario
@@ -22,13 +23,7 @@ ARG_VALUES1 = {
     "discharge_limit": 0.5,
     "cs_power_min": 0,
     "export_vehicle_id_csv": None,
-    "include_ext_load_csv": None,
-    "include_ext_load_csv_option": [],
-    "include_feed_in_csv": None,
-    "include_feed_in_csv_option": [],
     "seed": None,
-    "include_price_csv": None,
-    "include_price_csv_option": [],
     "verbose": 0,
     "voltage_level": "MV",
     # generate_schedule
@@ -186,6 +181,36 @@ class TestGenerate(TestCaseBase):
         })
         generate(Namespace(**current_arg_values))
         self.assertIsFile(output_file)
+
+    def test_generate_update_namespace(self):
+        # tests various more obscure options not covered by other tests
+        with pytest.raises(SystemExit):
+            # required options missing
+            generate(Namespace())
+
+        args = ARG_VALUES1.copy()
+        args.update({
+            # ignore output
+            "output": "/dev/null",
+            # no vehicle_types given
+            "vehicle_types": None,
+            # no voltage_level given
+            "voltage_level": None,
+            # pv_power given
+            "pv_power": 100,
+            # unlimited battery
+            "battery": [(-1, 1)],
+            # CSV file does not exist
+            "include_ext_load_csv": "DOES NOT EXIST",
+            # wrong column
+            "include_price_csv": str(TEST_REPO_PATH / "../examples/data/price_sheet.json"),
+            "include_price_csv_option": [("column", "DOES NOT EXIST")],
+            # CSV options without file
+            "include_feed_in_csv_option": [("grid_connector_id", "GC")],
+        })
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            generate(Namespace(**args))
 
 
 class TestGenerateSchedule(TestCaseBase):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -99,8 +99,14 @@ class TestReport:
                 },
                 "vehicle_types": {
                     "test": {"name": "test", "capacity": 10, "charging_curve": [[0, 1], [1, 1]]}},
-                "vehicles": {"t1": {"vehicle_type": "test", "soc": 0.3, "desired_soc": 0.5, "connected_charging_station": "cs", "schedule": 5}},
-                "charging_stations": {"cs": {"max_power": 10,"parent": "GC"}},
+                "vehicles": {"t1": {
+                    "vehicle_type": "test",
+                    "soc": 0.3,
+                    "desired_soc": 0.5,
+                    "connected_charging_station": "cs",
+                    "schedule": 5
+                }},
+                "charging_stations": {"cs": {"max_power": 10, "parent": "GC"}},
                 "batteries": {"BAT": {
                     "parent": "GC",
                     "charging_curve": [(0, 10), (1, 10)],

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -154,7 +154,7 @@ class TestScenarios(TestCaseBase):
             },
             "components": {
                 "vehicle_types": {
-                    "test": {"name": "t", "capacity": 100, "charging_curve": [[0, 100], [1, 100]]}},
+                    "t": {"name": "t", "capacity": 100, "charging_curve": [[0, 100], [1, 100]]}},
                 "vehicles": {"t1": {"vehicle_type": "t", "soc": 0.3, "desired_soc": 0.5}}
             },
             "events": {"vehicle_events": [{

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -118,7 +118,7 @@ class TestScenarios(TestCaseBase):
                 "start_time": "2020-01-01T00:35:00+02:00",
                 "grid_connector_id": "GC1",
                 "max_power": 2000,
-              },{
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T00:50:00+02:00",
                 "grid_connector_id": "GC1",
@@ -154,8 +154,8 @@ class TestScenarios(TestCaseBase):
             },
             "components": {
                 "vehicle_types": {
-                    "test": {"name": "test", "capacity": 100, "charging_curve": [[0, 100], [1, 100]]}},
-                "vehicles": {"t1": {"vehicle_type": "test", "soc": 0.3, "desired_soc": 0.5}}
+                    "test": {"name": "t", "capacity": 100, "charging_curve": [[0, 100], [1, 100]]}},
+                "vehicles": {"t1": {"vehicle_type": "t", "soc": 0.3, "desired_soc": 0.5}}
             },
             "events": {"vehicle_events": [{
                 "signal_time": "1970-01-01T00:00:00+02:00",
@@ -163,31 +163,32 @@ class TestScenarios(TestCaseBase):
                 "vehicle_id": "t1",
                 "event_type": "departure",
                 "update": {}
-              },{
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T00:05:00+02:00",
                 "vehicle_id": "t1",
                 "event_type": "arrival",
                 "update": {"soc_delta": -0.1, "desired_soc": 0.5}
-              },{
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T00:20:00+02:00",
                 "vehicle_id": "t1",
                 "event_type": "departure",
                 "update": {}
-              },{
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T00:35:00+02:00",
                 "vehicle_id": "t1",
                 "event_type": "arrival",
-                "update": {"soc_delta": -0.6, "desired_soc": 0.5, "connected_charging_station": "cs"}
-              },{
+                "update": {
+                    "soc_delta": -0.6, "desired_soc": 0.5, "connected_charging_station": "cs"}
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T00:50:00+02:00",
                 "vehicle_id": "t1",
                 "event_type": "departure",
                 "update": {}
-              },{
+              }, {
                 "signal_time": "2020-01-01T00:00:00+02:00",
                 "start_time": "2020-01-01T01:05:00+02:00",
                 "vehicle_id": "t1",
@@ -460,11 +461,12 @@ class TestScenarios(TestCaseBase):
         strat.world_state.grid_connectors["GC"].cost["value"] = 0.1
         strat.update_batteries()
         # battery not charged because price higher than threshold
-        assert strat.world_state.batteries["BAT"].soc  == 0.5
+        assert strat.world_state.batteries["BAT"].soc == 0.5
         strat.world_state.grid_connectors["GC"].cost["value"] = -0.1
         strat.update_batteries()
         # battery charged because price is lower than threshold
         assert strat.world_state.batteries["BAT"].soc > 0.5
+
 
 def test_apply_battery_losses():
     test_json = {

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -44,6 +44,7 @@ class TestCaseBase:
 
 class TestScenarios(TestCaseBase):
 
+    # TEST BASIC FUNCTIONALITY
     def test_scenario_times(self):
         # correct number of timesteps?
         j = get_test_json()
@@ -67,20 +68,161 @@ class TestScenarios(TestCaseBase):
         scenario.Scenario(j)
 
     def test_empty(self):
-        s = scenario.Scenario({
+        test_json = {
             "scenario": {
                 "start_time": "2020-01-01T00:00:00+02:00",
                 "interval": 15,
                 "n_intervals": 10
-            }})
+            }
+        }
+        s = scenario.Scenario(test_json)
         s.run('greedy', {})
         assert s.n_intervals == 10
         assert s.step_i == 10
+
+        test_json["components"] = {"grid_connectors": {"GC1": {"max_power": 42}}}
+        s = scenario.Scenario(test_json)
+        strat = strategy.Strategy(s.components, s.start_time, **{"interval": s.interval})
+        with pytest.raises(Exception):
+            # GC has neither cost nor schedule
+            strat.step()
 
     def test_file(self):
         # open from file
         input = TEST_REPO_PATH / 'test_data/input_test_strategies/scenario_A.json'
         scenario.Scenario(load_json(input), input.parent)
+
+    def test_set_connector_power(self):
+        s = scenario.Scenario({
+            "scenario": {
+                "start_time": "2020-01-01T00:00:00+02:00",
+                "interval": 15,
+                "n_intervals": 10
+            },
+            "components": {"grid_connectors": {"GC1": {
+                "max_power": 1000,
+                "cost": {"type": "fixed", "value": 0.1}
+            }}},
+            "events": {"grid_operator_signals": [{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:05:00+02:00",
+                "grid_connector_id": "GC1",
+                "max_power": 500,
+              }, {
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:25:00+02:00",
+                "grid_connector_id": "GC1",
+                "cost": {"type": "fixed", "value": 0.2}
+              }, {
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:35:00+02:00",
+                "grid_connector_id": "GC1",
+                "max_power": 2000,
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:50:00+02:00",
+                "grid_connector_id": "GC1",
+                "max_power": 2000,
+              },
+            ]}
+        })
+        strat = strategy.Strategy(s.components, s.start_time, **{"interval": s.interval})
+        event_steps = s.events.get_event_steps(s.start_time, s.n_intervals, s.interval)
+        strat.step(event_steps[0])
+        # start of scenario: initial value
+        assert strat.world_state.grid_connectors["GC1"].cur_max_power == 1000
+        strat.step()
+        # first step: max_power set
+        assert strat.world_state.grid_connectors["GC1"].cur_max_power == 500
+        strat.step()
+        # second step: grid event without max_power => retain value
+        assert strat.world_state.grid_connectors["GC1"].cur_max_power == 500
+        strat.step()
+        # third step: max_power higher than initial value: clip
+        assert strat.world_state.grid_connectors["GC1"].cur_max_power == 1000
+        # fourth step: no max power of connector: set max_power of event
+        strat.world_state.grid_connectors["GC1"].max_power = None
+        strat.step()
+        assert strat.world_state.grid_connectors["GC1"].cur_max_power == 2000
+
+    def test_vehicle_soc(self):
+        s = scenario.Scenario({
+            "scenario": {
+                "start_time": "2020-01-01T00:00:00+02:00",
+                "interval": 15,
+                "n_intervals": 10
+            },
+            "components": {
+                "vehicle_types": {
+                    "test": {"name": "test", "capacity": 100, "charging_curve": [[0, 100], [1, 100]]}},
+                "vehicles": {"t1": {"vehicle_type": "test", "soc": 0.3, "desired_soc": 0.5}}
+            },
+            "events": {"vehicle_events": [{
+                "signal_time": "1970-01-01T00:00:00+02:00",
+                "start_time": "1970-01-01T00:00:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "departure",
+                "update": {}
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:05:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "arrival",
+                "update": {"soc_delta": -0.1, "desired_soc": 0.5}
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:20:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "departure",
+                "update": {}
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:35:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "arrival",
+                "update": {"soc_delta": -0.6, "desired_soc": 0.5, "connected_charging_station": "cs"}
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T00:50:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "departure",
+                "update": {}
+              },{
+                "signal_time": "2020-01-01T00:00:00+02:00",
+                "start_time": "2020-01-01T01:05:00+02:00",
+                "vehicle_id": "t1",
+                "event_type": "arrival",
+                "update": {"soc_delta": -0.6, "desired_soc": 0.5}
+              },
+            ]}
+        })
+        strat = strategy.Strategy(s.components, s.start_time, **{"interval": s.interval})
+        event_steps = s.events.get_event_steps(s.start_time, s.n_intervals, s.interval)
+        # pre-step: initial soc
+        assert strat.world_state.vehicles["t1"].battery.soc == 0.3
+        # first step: update for timesteps before scenario start (set desired soc if needed)
+        strat.step(event_steps[0])
+        assert strat.world_state.vehicles["t1"].battery.soc == 0.5
+        # second step: normal arrival with delta_soc = 0.1
+        strat.step()
+        assert strat.world_state.vehicles["t1"].battery.soc == 0.4
+        strat.world_state.vehicles["t1"].battery.soc = 0.5
+        # third step: normal departure
+        strat.step()
+        assert strat.world_state.vehicles["t1"].battery.soc == 0.5
+        # fourth step: arrival with negative soc
+        strat.ALLOW_NEGATIVE_SOC = True
+        strat.RESET_NEGATIVE_SOC = True
+        strat.step()
+        assert strat.world_state.vehicles["t1"].battery.soc == 0
+        # fifth step: departure with soc below desired
+        strat.world_state.vehicles["t1"].battery.soc = 0.4
+        strat.step()
+        assert strat.margin_counter == 1
+        # sixth step: error when arriving with negative soc
+        strat.ALLOW_NEGATIVE_SOC = False
+        with pytest.raises(RuntimeError):
+            strat.step()
 
     # TEST SCENARIOS WITH BATTERY, FEEDIN AND EXTERNAL LOAD (Scenario A)
     def test_scenario_A(self):
@@ -293,6 +435,36 @@ class TestScenarios(TestCaseBase):
         # test battery
         assert pytest.approx(s.batteryLevels["BAT"][-1]) == 0
 
+    def test_low_price(self):
+        s = scenario.Scenario({
+            "scenario": {
+                "start_time": "2020-01-01T00:00:00+02:00",
+                "interval": 15,
+                "n_intervals": 10
+            },
+            "components": {
+                "grid_connectors": {"GC": {
+                    "max_power": 100,
+                    "cost": {"type": "fixed", "value": 0.1}
+                }},
+                "batteries": {"BAT": {
+                    "parent": "GC",
+                    "charging_curve": [(0, 10), (1, 10)],
+                    "capacity": 10,
+                    "soc": 0.5,
+                }}
+            }
+        })
+        strat = strategy.Strategy(s.components, s.start_time, **{"interval": s.interval})
+        strat.PRICE_THRESHOLD = 0
+        strat.world_state.grid_connectors["GC"].cost["value"] = 0.1
+        strat.update_batteries()
+        # battery not charged because price higher than threshold
+        assert strat.world_state.batteries["BAT"].soc  == 0.5
+        strat.world_state.grid_connectors["GC"].cost["value"] = -0.1
+        strat.update_batteries()
+        # battery charged because price is lower than threshold
+        assert strat.world_state.batteries["BAT"].soc > 0.5
 
 def test_apply_battery_losses():
     test_json = {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -185,11 +185,12 @@ class TestUtil:
         # create dummy config:
         """
         foo= bar
+
         # comment
         baf =1
         array = [1]
         """
-        (tmp_path / "config.cfg").write_text("foo= bar\n#comment\nbaf =1\narray = [1]")
+        (tmp_path / "config.cfg").write_text("foo= bar\n\n#comment\nbaf =1\narray = [1]")
         # no config: no update
         util.set_options_from_config(ns)
         assert ns.baf == 2


### PR DESCRIPTION
- generate: CSV options truly optional, slight refactoring of CSV code. Test more obscure options
- report: catch empty soc and charging stations while plotting. Test plotting
- strategy: set default PRICE_THRESHOLD of 0, don't reset GC max_power when GC event has no max_power field. More event testing, test low prices
- test schedule with V2G
- util.set_options_from_config: test empty line