### PR TITLE
Feature/feed in remuneration

### DIFF
--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -22,6 +22,7 @@ def read_simulation_csv(csv_file):
     price_list = []  # [€/kWh]
     power_grid_supply_list = []  # [kW]
     power_fix_load_list = []  # [kW]
+    power_pv_feed_in_list = [] # [kW]
     charging_signal_list = []  # [-]
     with open(csv_file, "r", newline="") as simulation_data:
         reader = csv.DictReader(simulation_data, delimiter=",")
@@ -40,6 +41,12 @@ def read_simulation_csv(csv_file):
             power_fix_load_list.append(power_fix_load)
 
             try:
+                power_generation_feed_in = float(row["generation feed-in [kW]"])
+            except KeyError:
+                power_generation_feed_in = 0.0
+            power_pv_feed_in_list.append(power_generation_feed_in)
+
+            try:
                 charging_signal = bool(int(row["window signal [-]"]))
             except KeyError:
                 charging_signal = None
@@ -50,6 +57,7 @@ def read_simulation_csv(csv_file):
         "price_list": price_list,
         "power_grid_supply_list": power_grid_supply_list,
         "power_fix_load_list": power_fix_load_list,
+        "power_generation_feed_in_list": power_pv_feed_in_list,
         "charging_signal_list": charging_signal_list,
     }
 

--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -22,7 +22,7 @@ def read_simulation_csv(csv_file):
     price_list = []  # [€/kWh]
     power_grid_supply_list = []  # [kW]
     power_fix_load_list = []  # [kW]
-    power_pv_feed_in_list = [] # [kW]
+    power_pv_feed_in_list = []  # [kW]
     charging_signal_list = []  # [-]
     with open(csv_file, "r", newline="") as simulation_data:
         reader = csv.DictReader(simulation_data, delimiter=",")

--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -23,6 +23,8 @@ def read_simulation_csv(csv_file):
     power_grid_supply_list = []  # [kW]
     power_fix_load_list = []  # [kW]
     power_generation_feed_in_list = []  # [kW]
+    power_v2g_feed_in_list = []  # [kW]
+    power_battery_feed_in_list = []  # [kW]
     charging_signal_list = []  # [-]
     with open(csv_file, "r", newline="") as simulation_data:
         reader = csv.DictReader(simulation_data, delimiter=",")
@@ -34,6 +36,8 @@ def read_simulation_csv(csv_file):
             power_grid_supply = float(row["grid supply [kW]"])
             power_fix_load = float(row["fixed load [kW]"])
             power_generation_feed_in = float(row.get("generation feed-in [kW]", 0))
+            power_v2g_feed_in = float(row.get("V2G feed-in [kW]", 0))
+            power_battery_feed_in = float(row.get("battery feed-in [kW]", 0))
 
             # append value to the respective list:
             timestamps_list.append(timestamp)
@@ -41,6 +45,8 @@ def read_simulation_csv(csv_file):
             power_grid_supply_list.append(power_grid_supply)
             power_fix_load_list.append(power_fix_load)
             power_generation_feed_in_list.append(power_generation_feed_in)
+            power_v2g_feed_in_list.append(power_v2g_feed_in)
+            power_battery_feed_in_list.append(power_battery_feed_in)
 
             try:
                 charging_signal = bool(int(row["window signal [-]"]))
@@ -54,6 +60,8 @@ def read_simulation_csv(csv_file):
         "power_grid_supply_list": power_grid_supply_list,
         "power_fix_load_list": power_fix_load_list,
         "power_generation_feed_in_list": power_generation_feed_in_list,
+        "power_v2g_feed_in_list": power_v2g_feed_in_list,
+        "power_battery_feed_in_list": power_battery_feed_in_list,
         "charging_signal_list": charging_signal_list,
     }
 

--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -22,7 +22,7 @@ def read_simulation_csv(csv_file):
     price_list = []  # [€/kWh]
     power_grid_supply_list = []  # [kW]
     power_fix_load_list = []  # [kW]
-    power_pv_feed_in_list = []  # [kW]
+    power_generation_feed_in_list = []  # [kW]
     charging_signal_list = []  # [-]
     with open(csv_file, "r", newline="") as simulation_data:
         reader = csv.DictReader(simulation_data, delimiter=",")
@@ -33,18 +33,14 @@ def read_simulation_csv(csv_file):
             price = float(row.get("price [EUR/kWh]", 0))
             power_grid_supply = float(row["grid supply [kW]"])
             power_fix_load = float(row["fixed load [kW]"])
+            power_generation_feed_in = float(row.get("generation feed-in [kW]", 0))
 
             # append value to the respective list:
             timestamps_list.append(timestamp)
             price_list.append(price)
             power_grid_supply_list.append(power_grid_supply)
             power_fix_load_list.append(power_fix_load)
-
-            try:
-                power_generation_feed_in = float(row["generation feed-in [kW]"])
-            except KeyError:
-                power_generation_feed_in = 0.0
-            power_pv_feed_in_list.append(power_generation_feed_in)
+            power_generation_feed_in_list.append(power_generation_feed_in)
 
             try:
                 charging_signal = bool(int(row["window signal [-]"]))
@@ -57,7 +53,7 @@ def read_simulation_csv(csv_file):
         "price_list": price_list,
         "power_grid_supply_list": power_grid_supply_list,
         "power_fix_load_list": power_fix_load_list,
-        "power_generation_feed_in_list": power_pv_feed_in_list,
+        "power_generation_feed_in_list": power_generation_feed_in_list,
         "charging_signal_list": charging_signal_list,
     }
 

--- a/doc/source/code.rst
+++ b/doc/source/code.rst
@@ -338,6 +338,7 @@ respective options are selected in the `simulate.cfg`.
 
     aggregate_global_results
     aggregate_local_results
+    split_feedin
     aggregate_timeseries
     generate_soc_timeseries
     plot

--- a/examples/data/price_sheet.json
+++ b/examples/data/price_sheet.json
@@ -99,6 +99,7 @@
             "remuneration": [6.24, 6.06, 4.74]
         },
         "V2G": 0,
+        "battery": 0,
         "unit": "ct/kWh",
         "info": "remuneration for power fed into the grid by PV power plants or electric vehicles"
     },

--- a/examples/output/calculate_costs_results.json
+++ b/examples/output/calculate_costs_results.json
@@ -127,7 +127,8 @@
         },
         "feed-in remuneration": {
           "PV": 0.0,
-          "V2G": "to be implemented"
+          "V2G": 0.0,
+          "battery": 0.0
         },
         "unit": "EUR",
         "info": "energy costs for one year"
@@ -163,7 +164,8 @@
         },
         "feed-in remuneration": {
           "PV": 0.0,
-          "V2G": "to be implemented"
+          "V2G": 0.0,
+          "battery": 0.0
         },
         "unit": "EUR",
         "info": "energy costs for simulation period"

--- a/examples/output/simulation.json
+++ b/examples/output/simulation.json
@@ -127,7 +127,8 @@
         },
         "feed-in remuneration": {
           "PV": 0.0,
-          "V2G": "to be implemented"
+          "V2G": 0.0,
+          "battery": 0.0
         },
         "unit": "EUR",
         "info": "energy costs for one year"
@@ -163,7 +164,8 @@
         },
         "feed-in remuneration": {
           "PV": 0.0,
-          "V2G": "to be implemented"
+          "V2G": 0.0,
+          "battery": 0.0
         },
         "unit": "EUR",
         "info": "energy costs for simulation period"

--- a/simulate.py
+++ b/simulate.py
@@ -85,6 +85,7 @@ def simulate(args):
                 power_grid_supply_list=timeseries.get("grid supply [kW]"),
                 price_list=timeseries.get("price [EUR/kWh]"),
                 power_fix_load_list=timeseries.get("fixed load [kW]"),
+                power_generation_feed_in_list=timeseries.get("generation feed-in [kW]"),
                 charging_signal_list=timeseries.get("window signal [-]"),
                 core_standing_time_dict=s.core_standing_time,
                 price_sheet_json=args.get("cost_parameters_file"),

--- a/simulate.py
+++ b/simulate.py
@@ -86,6 +86,8 @@ def simulate(args):
                 price_list=timeseries.get("price [EUR/kWh]"),
                 power_fix_load_list=timeseries.get("fixed load [kW]"),
                 power_generation_feed_in_list=timeseries.get("generation feed-in [kW]"),
+                power_v2g_feed_in_list=timeseries.get("V2G feed-in [kW]"),
+                power_battery_feed_in_list=timeseries.get("battery feed-in [kW]"),
                 charging_signal_list=timeseries.get("window signal [-]"),
                 core_standing_time_dict=s.core_standing_time,
                 price_sheet_json=args.get("cost_parameters_file"),

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -179,8 +179,7 @@ def calculate_costs(strategy, voltage_level, interval,
     # fraction of scenario duration in relation to one year
     fraction_year = len(timestamps_list) * interval / datetime.timedelta(days=365)
 
-    # split power into feed-in and supply (change sign)
-    # power_feed_in_list = [max(v, 0) for v in power_grid_supply_list]
+    # extract actual grid supply (change sign)
     power_grid_supply_list = [max(-v, 0) for v in power_grid_supply_list]
 
     # only consider positive values of fixed load for cost calculation
@@ -558,14 +557,14 @@ def calculate_costs(strategy, voltage_level, interval,
     # energy feed in by PV power plant:
     if power_generation_feed_in_list is None:
         power_generation_feed_in_list = [0] * len(timestamps_list)
-    energy_feed_in_generation_sim = sum(power_generation_feed_in_list)\
-        * interval.total_seconds() / 3600  # [kWh]
+    energy_feed_in_generation_sim = (
+            sum(power_generation_feed_in_list) * interval.total_seconds() / 3600)  # [kWh]
     energy_feed_in_generation_per_year = energy_feed_in_generation_sim / fraction_year  # [kWh]
 
     # costs for PV feed-in:
     pv_feed_in_costs_sim = energy_feed_in_generation_sim * feed_in_charge_pv / 100  # [EUR]
-    pv_feed_in_costs_per_year = energy_feed_in_generation_per_year\
-        * feed_in_charge_pv / 100  # [EUR]
+    pv_feed_in_costs_per_year = (
+            energy_feed_in_generation_per_year * feed_in_charge_pv / 100)  # [EUR]
 
     # COSTS FROM TAXES AND TOTAL COSTS:
 

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -591,7 +591,8 @@ def calculate_costs(strategy, voltage_level, interval,
     else:
         feed_in_charge_pv = 0  # [ct/kWh]
         if power_generation_feed_in_list is not None:
-            warnings.warn("Nominal power of PV power plant is zero even though there is an existing generation time series")
+            warnings.warn("Nominal power of PV power plant is zero even though there is an "
+                          "existing generation time series")
 
     # remuneration for PV feed-in:
     pv_feed_in_costs_per_year, pv_feed_in_costs_sim = calculate_feed_in_remuneration(

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -128,9 +128,40 @@ def calculate_capacity_costs_rlm(capacity_charge, max_power_strategy):
     return capacity_charge * max_power_strategy  # [€]
 
 
+def calculate_feed_in_remuneration(feed_in_charge, power_feed_in_list,
+                                   timestamps_list, interval, fraction_year):
+    '''Calculates the feed-in remuneration per year and simulation period
+    :param feed_in_charge: feed-in charge
+    :type feed_in_charge: float
+    :param power_feed_in_list: power fed into the grid
+    :type power_feed_in_list: list
+    :param timestamps_list: timestamps of simulated points in time
+    :type timestamps_list: list
+    :param interval: simulation interval
+    :type interval: timedelta
+    :param fraction_year: simulation time relative to one year
+    :type fraction_year: float
+    :return: feed-in remuneration per year and simulation period in Euro
+    :rtype: float
+    '''
+    if power_feed_in_list is None:
+        power_feed_in_list = [0] * len(timestamps_list)
+    energy_feed_in_sim = (
+            sum(power_feed_in_list) * interval.total_seconds() / 3600)  # [kWh]
+    energy_feed_in_per_year = energy_feed_in_sim / fraction_year  # [kWh]
+
+    # costs for PV feed-in:
+    feed_in_costs_sim = energy_feed_in_sim * feed_in_charge / 100  # [EUR]
+    feed_in_costs_per_year = (
+            energy_feed_in_per_year * feed_in_charge / 100)  # [EUR]
+
+    return feed_in_costs_per_year, feed_in_costs_sim
+
+
 def calculate_costs(strategy, voltage_level, interval,
                     timestamps_list, power_grid_supply_list,
                     price_list, power_fix_load_list, power_generation_feed_in_list,
+                    power_v2g_feed_in_list, power_battery_feed_in_list,
                     charging_signal_list, core_standing_time_dict, price_sheet_json,
                     results_json=None, power_pv_nominal=0):
     """Calculate costs for the chosen charging strategy
@@ -151,6 +182,10 @@ def calculate_costs(strategy, voltage_level, interval,
     :type power_fix_load_list: list
     :param power_generation_feed_in_list: power fed into the grid from local generation
     :type power_generation_feed_in_list: list
+    :param power_v2g_feed_in_list: power fed into the grid from V2G
+    :type power_v2g_feed_in_list: list
+    :param power_battery_feed_in_list: power fed into the grid from battery
+    :type power_battery_feed_in_list: list
     :param charging_signal_list: charging signal (True (1): charge, False (0): don't charge)
     :type charging_signal_list: list
     :param core_standing_time_dict: defined core standing time of the fleet
@@ -534,8 +569,9 @@ def calculate_costs(strategy, voltage_level, interval,
 
     # COSTS FROM FEED-IN REMUNERATION:
 
-    # get nominal power of pv power plant:
+    # feed-in remuneration PV:
 
+    # get nominal power of pv power plant:
     # PV power plant existing:
     if power_pv_nominal != 0:
         # find charge for PV remuneration depending on nominal power pf PV plant:
@@ -553,18 +589,26 @@ def calculate_costs(strategy, voltage_level, interval,
     # PV power plant not existing:
     else:
         feed_in_charge_pv = 0  # [ct/kWh]
+    # remuneration for PV feed-in:
+    pv_feed_in_costs_per_year, pv_feed_in_costs_sim = calculate_feed_in_remuneration(
+        feed_in_charge_pv, power_generation_feed_in_list, timestamps_list, interval, fraction_year)
 
-    # energy feed in by PV power plant:
-    if power_generation_feed_in_list is None:
-        power_generation_feed_in_list = [0] * len(timestamps_list)
-    energy_feed_in_generation_sim = (
-            sum(power_generation_feed_in_list) * interval.total_seconds() / 3600)  # [kWh]
-    energy_feed_in_generation_per_year = energy_feed_in_generation_sim / fraction_year  # [kWh]
+    # feed-in remuneration V2G:
 
-    # costs for PV feed-in:
-    pv_feed_in_costs_sim = energy_feed_in_generation_sim * feed_in_charge_pv / 100  # [EUR]
-    pv_feed_in_costs_per_year = (
-            energy_feed_in_generation_per_year * feed_in_charge_pv / 100)  # [EUR]
+    # charge for V2G remuneration:
+    feed_in_charge_v2g = price_sheet["feed-in_remuneration"]["V2G"]
+    # remuneration for V2G feed-in:
+    v2g_feed_in_costs_per_year, v2g_feed_in_costs_sim = calculate_feed_in_remuneration(
+        feed_in_charge_v2g, power_v2g_feed_in_list, timestamps_list, interval, fraction_year)
+
+    # feed-in remuneration battery:
+
+    # charge for battery feed-in remuneration:
+    feed_in_charge_battery = price_sheet["feed-in_remuneration"]["battery"]
+    # remuneration for battery feed-in:
+    battery_feed_in_costs_per_year, battery_feed_in_costs_sim = calculate_feed_in_remuneration(
+        feed_in_charge_battery, power_battery_feed_in_list, timestamps_list, interval,
+        fraction_year)
 
     # COSTS FROM TAXES AND TOTAL COSTS:
 
@@ -605,9 +649,18 @@ def calculate_costs(strategy, voltage_level, interval,
 
     # aggregated and rounded values
     round_to_places = 2
-    total_costs_sim = round(costs_total_value_added_eur_sim - pv_feed_in_costs_sim, round_to_places)
+    total_costs_sim = round(
+        costs_total_value_added_eur_sim
+        - pv_feed_in_costs_sim
+        - v2g_feed_in_costs_sim
+        - battery_feed_in_costs_sim,
+        round_to_places)
     total_costs_per_year = round(
-        costs_total_value_added_eur_per_year - pv_feed_in_costs_per_year, round_to_places)
+        costs_total_value_added_eur_per_year
+        - pv_feed_in_costs_per_year
+        - v2g_feed_in_costs_per_year
+        - battery_feed_in_costs_per_year,
+        round_to_places)
 
     commodity_costs_eur_per_year = round(commodity_costs_eur_per_year, round_to_places)
     capacity_costs_eur = round(capacity_costs_eur, round_to_places)
@@ -626,7 +679,11 @@ def calculate_costs(strategy, voltage_level, interval,
         round(value_added_tax_costs_per_year, round_to_places),
         round_to_places)
 
-    feed_in_remuneration_per_year = round(pv_feed_in_costs_per_year, round_to_places)
+    feed_in_remuneration_per_year = round(
+        pv_feed_in_costs_per_year
+        + v2g_feed_in_costs_per_year
+        + battery_feed_in_costs_per_year,
+        round_to_places)
 
     # WRITE ALL COSTS INTO JSON:
     if results_json is not None:
@@ -680,8 +737,9 @@ def calculate_costs(strategy, voltage_level, interval,
                         "tax on electricity": round(electricity_tax_costs_per_year, round_to_places)
                     },
                     "feed-in remuneration": {
-                        "PV": feed_in_remuneration_per_year,
-                        "V2G": "to be implemented"
+                        "PV": round(pv_feed_in_costs_per_year, round_to_places),
+                        "V2G": round(v2g_feed_in_costs_per_year, round_to_places),
+                        "battery": round(battery_feed_in_costs_per_year, round_to_places)
                     },
                     "unit": "EUR",
                     "info": "energy costs for one year",
@@ -720,7 +778,8 @@ def calculate_costs(strategy, voltage_level, interval,
                     },
                     "feed-in remuneration": {
                         "PV": round(pv_feed_in_costs_sim, round_to_places),
-                        "V2G": "to be implemented"
+                        "V2G": round(v2g_feed_in_costs_sim, round_to_places),
+                        "battery": round(battery_feed_in_costs_sim, round_to_places)
                     },
                     "unit": "EUR",
                     "info": "energy costs for simulation period",

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -131,7 +131,7 @@ def calculate_capacity_costs_rlm(capacity_charge, max_power_strategy):
 
 def calculate_feed_in_remuneration(feed_in_charge, power_feed_in_list,
                                    timestamps_list, interval, fraction_year):
-    '''Calculates the feed-in remuneration per year and simulation period
+    """Calculates the feed-in remuneration per year and simulation period
     :param feed_in_charge: feed-in charge
     :type feed_in_charge: float
     :param power_feed_in_list: power fed into the grid
@@ -144,17 +144,15 @@ def calculate_feed_in_remuneration(feed_in_charge, power_feed_in_list,
     :type fraction_year: float
     :return: feed-in remuneration per year and simulation period in Euro
     :rtype: float
-    '''
+    """
     if power_feed_in_list is None:
         power_feed_in_list = [0] * len(timestamps_list)
-    energy_feed_in_sim = (
-            sum(power_feed_in_list) * interval.total_seconds() / 3600)  # [kWh]
+    energy_feed_in_sim = sum(power_feed_in_list) * interval.total_seconds() / 3600  # [kWh]
     energy_feed_in_per_year = energy_feed_in_sim / fraction_year  # [kWh]
 
     # costs for PV feed-in:
     feed_in_costs_sim = energy_feed_in_sim * feed_in_charge / 100  # [EUR]
-    feed_in_costs_per_year = (
-            energy_feed_in_per_year * feed_in_charge / 100)  # [EUR]
+    feed_in_costs_per_year = energy_feed_in_per_year * feed_in_charge / 100  # [EUR]
 
     return feed_in_costs_per_year, feed_in_costs_sim
 

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -1,5 +1,6 @@
 import json
 import datetime
+import warnings
 
 from spice_ev import util
 
@@ -589,6 +590,9 @@ def calculate_costs(strategy, voltage_level, interval,
     # PV power plant not existing:
     else:
         feed_in_charge_pv = 0  # [ct/kWh]
+        if power_generation_feed_in_list is not None:
+            warnings.warn("Nominal power of PV power plant is zero even though there is an existing generation time series")
+
     # remuneration for PV feed-in:
     pv_feed_in_costs_per_year, pv_feed_in_costs_sim = calculate_feed_in_remuneration(
         feed_in_charge_pv, power_generation_feed_in_list, timestamps_list, interval, fraction_year)

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -130,9 +130,9 @@ def calculate_capacity_costs_rlm(capacity_charge, max_power_strategy):
 
 def calculate_costs(strategy, voltage_level, interval,
                     timestamps_list, power_grid_supply_list,
-                    price_list, power_fix_load_list, power_generation_feed_in_list, charging_signal_list,
-                    core_standing_time_dict, price_sheet_json, results_json=None,
-                    power_pv_nominal=0):
+                    price_list, power_fix_load_list, power_generation_feed_in_list,
+                    charging_signal_list, core_standing_time_dict, price_sheet_json,
+                    results_json=None, power_pv_nominal=0):
     """Calculate costs for the chosen charging strategy
 
     :param strategy: charging strategy
@@ -554,16 +554,18 @@ def calculate_costs(strategy, voltage_level, interval,
     # PV power plant not existing:
     else:
         feed_in_charge_pv = 0  # [ct/kWh]
-    print(power_generation_feed_in_list)
+
     # energy feed in by PV power plant:
     if power_generation_feed_in_list is None:
         power_generation_feed_in_list = [0] * len(timestamps_list)
-    energy_feed_in_generation_sim = sum(power_generation_feed_in_list) * interval.total_seconds() / 3600  # [kWh]
+    energy_feed_in_generation_sim = sum(power_generation_feed_in_list)\
+        * interval.total_seconds() / 3600  # [kWh]
     energy_feed_in_generation_per_year = energy_feed_in_generation_sim / fraction_year  # [kWh]
 
     # costs for PV feed-in:
     pv_feed_in_costs_sim = energy_feed_in_generation_sim * feed_in_charge_pv / 100  # [EUR]
-    pv_feed_in_costs_per_year = energy_feed_in_generation_per_year * feed_in_charge_pv / 100  # [EUR]
+    pv_feed_in_costs_per_year = energy_feed_in_generation_per_year\
+        * feed_in_charge_pv / 100  # [EUR]
 
     # COSTS FROM TAXES AND TOTAL COSTS:
 

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -251,8 +251,8 @@ class TestSimulationCosts:
             None,  # empty charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
-        # TODO compare expected values
-        assert result is not None
+        assert result["commodity_costs_eur_per_year"] == 33969.33
+        assert result["capacity_costs_eur"] == 41060
 
     def test_fixed_load(self):
         for strategy in ["balanced_market", "flex_window", "schedule"]:

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -285,7 +285,7 @@ class TestSimulationCosts:
                 [pv]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
-                [5] * 9,  # empty feed-in from local generation
+                [5] * 9,  # feed-in from local generation
                 [0] * 9,  # empty feed-in from V2G
                 [0] * 9,  # empty feed-in from battery
                 None,  # no charging signal
@@ -327,16 +327,16 @@ class TestSimulationCosts:
             results_json=dst)
         with dst.open('r') as f:
             results_json = json.load(f)
-            assert results_json['costs']['electricity costs']['per year']['total (gross)']\
-                   == result["total_costs_per_year"]
-            assert results_json['costs']['electricity costs']['per year']['grid_fee'][
-                       'commodity costs']['total costs']\
-                   == result["commodity_costs_eur_per_year"]
-            assert results_json['costs']['electricity costs']['per year']['grid_fee'][
-                       'capacity_or_basic_costs']['total costs']\
-                   == result["capacity_costs_eur"]
-            assert results_json['costs']['electricity costs']['per year']['power procurement']\
-                   == result["power_procurement_costs_per_year"]
+            assert (results_json['costs']['electricity costs']['per year']['total (gross)']
+                   == result["total_costs_per_year"])
+            assert (results_json['costs']['electricity costs']['per year']['grid_fee'][
+                       'commodity costs']['total costs']
+                   == result["commodity_costs_eur_per_year"])
+            assert (results_json['costs']['electricity costs']['per year']['grid_fee'][
+                       'capacity_or_basic_costs']['total costs']
+                   == result["capacity_costs_eur"])
+            assert (results_json['costs']['electricity costs']['per year']['power procurement']
+                   == result["power_procurement_costs_per_year"])
 
 
 class TestPostSimulationCosts:

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -277,22 +277,22 @@ class TestSimulationCosts:
             price_sheet_json = json.load(ps)
         # iterate over PV ranges
         pv_ranges = price_sheet_json["feed-in_remuneration"]["PV"]["kWp"]
-        for pv in pv_ranges:
+        results = [2733.12, 2654.28, 2076.12]
+        for i, pv in enumerate(pv_ranges):
             result = cc.calculate_costs(
                 "greedy", "MV", datetime.timedelta(hours=1),
                 [None]*9,  # empty timestamps
                 [pv]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
-                [0] * 9,  # empty feed-in from local generation
+                [5] * 9,  # empty feed-in from local generation
                 [0] * 9,  # empty feed-in from V2G
                 [0] * 9,  # empty feed-in from battery
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
                 power_pv_nominal=pv)
-            # TODO compare expected values
-            assert result is not None
+            assert result["feed_in_remuneration_per_year"] == results[i]
         with pytest.raises(ValueError):
             # PV out of range
             cc.calculate_costs(
@@ -301,7 +301,7 @@ class TestSimulationCosts:
                 [1]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
-                [0] * 9,  # empty feed-in from local generation
+                [5] * 9,  # empty feed-in from local generation
                 [0] * 9,  # empty feed-in from V2G
                 [0] * 9,  # empty feed-in from battery
                 None,  # no charging signal

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -70,7 +70,8 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0]*s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "window signal [-]"]]
+                            "local generation [kW]", "generation feed-in [kW]",
+                            "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         # test all supported strategies
@@ -117,7 +118,8 @@ class TestSimulationCosts:
             timeseries = s.GC1_timeseries
             timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "window signal [-]"]]
+                            "local generation [kW]", "generation feed-in [kW]",
+                            "window signal [-]"]]
             price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
             pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
             result = cc.calculate_costs("greedy", "MV", s.interval, *timeseries_lists,
@@ -135,7 +137,8 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "window signal [-]"]]
+                            "local generation [kW]", "generation feed-in [kW]",
+                            "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -160,7 +163,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                         "time", "grid supply [kW]", "price [EUR/kWh]",
-                        "local generation [kW]", "window signal [-]"]]
+                        "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -184,7 +187,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "local generation [kW]", "window signal [-]"]]
+            "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -209,7 +212,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "local generation [kW]", "window signal [-]"]]
+            "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -233,6 +236,7 @@ class TestSimulationCosts:
             [-1000] + [0]*8,  # single grid supply value
             None,  # empty prices
             [0] * 9,  # empty fix loads
+            [0] * 9,  # empty local generation
             None,  # empty charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -247,6 +251,7 @@ class TestSimulationCosts:
                 [0]*9,  # empty grid supply
                 [1]*9,  # static prices
                 [100] * 9,  # static fixed loads
+                [0] * 9,  # empty local generation
                 [True]*9,  # always-on charging signal
                 None,  # empty CST
                 TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -266,6 +271,7 @@ class TestSimulationCosts:
                 [pv]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
+                [0] * 9,  # empty local generation
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -280,6 +286,7 @@ class TestSimulationCosts:
                 [1]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
+                [0] * 9,  # empty local generation
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -294,6 +301,7 @@ class TestSimulationCosts:
             [0]*9,  # empty grid supply
             None,  # empty prices
             [0] * 9,  # empty fixed loads
+            [0] * 9,  # empty local generation
             None,  # no charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json',

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -312,7 +312,7 @@ class TestSimulationCosts:
     def test_write_results(self, tmp_path):
         dst = tmp_path / "results.json"
         dst.write_text("{}")
-        cc.calculate_costs(
+        result = cc.calculate_costs(
             "greedy", "MV", datetime.timedelta(hours=1),
             [None]*9,  # empty timestamps
             [0]*9,  # empty grid supply
@@ -327,8 +327,16 @@ class TestSimulationCosts:
             results_json=dst)
         with dst.open('r') as f:
             results_json = json.load(f)
-            # TODO compare expected values
-            assert results_json is not None
+            assert results_json['costs']['electricity costs']['per year']['total (gross)']\
+                   == result["total_costs_per_year"]
+            assert results_json['costs']['electricity costs']['per year']['grid_fee'][
+                       'commodity costs']['total costs']\
+                   == result["commodity_costs_eur_per_year"]
+            assert results_json['costs']['electricity costs']['per year']['grid_fee'][
+                       'capacity_or_basic_costs']['total costs']\
+                   == result["capacity_costs_eur"]
+            assert results_json['costs']['electricity costs']['per year']['power procurement']\
+                   == result["power_procurement_costs_per_year"]
 
 
 class TestPostSimulationCosts:

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -70,7 +70,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0]*s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "generation feed-in [kW]",
+                            "fixed load [kW]", "generation feed-in [kW]",
                             "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
@@ -118,7 +118,7 @@ class TestSimulationCosts:
             timeseries = s.GC1_timeseries
             timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "generation feed-in [kW]",
+                            "fixed load [kW]", "generation feed-in [kW]",
                             "window signal [-]"]]
             price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
             pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -137,7 +137,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
-                            "local generation [kW]", "generation feed-in [kW]",
+                            "fixed load [kW]", "generation feed-in [kW]",
                             "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
@@ -163,7 +163,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                         "time", "grid supply [kW]", "price [EUR/kWh]",
-                        "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
+                        "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -187,7 +187,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
+            "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -212,7 +212,7 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "local generation [kW]", "generation feed-in [kW]", "window signal [-]"]]
+            "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -236,7 +236,7 @@ class TestSimulationCosts:
             [-1000] + [0]*8,  # single grid supply value
             None,  # empty prices
             [0] * 9,  # empty fix loads
-            [0] * 9,  # empty local generation
+            [0] * 9,  # empty feed-in from local generation
             None,  # empty charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -251,7 +251,7 @@ class TestSimulationCosts:
                 [0]*9,  # empty grid supply
                 [1]*9,  # static prices
                 [100] * 9,  # static fixed loads
-                [0] * 9,  # empty local generation
+                [0] * 9,  # empty feed-in from local generation
                 [True]*9,  # always-on charging signal
                 None,  # empty CST
                 TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -271,7 +271,7 @@ class TestSimulationCosts:
                 [pv]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
-                [0] * 9,  # empty local generation
+                [0] * 9,  # empty feed-in from local generation
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -286,7 +286,7 @@ class TestSimulationCosts:
                 [1]*9,  # positive grid supply
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
-                [0] * 9,  # empty local generation
+                [0] * 9,  # empty feed-in from local generation
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -301,7 +301,7 @@ class TestSimulationCosts:
             [0]*9,  # empty grid supply
             None,  # empty prices
             [0] * 9,  # empty fixed loads
-            [0] * 9,  # empty local generation
+            [0] * 9,  # empty feed-in from local generation
             None,  # no charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json',

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -268,8 +268,8 @@ class TestSimulationCosts:
                 [True]*9,  # always-on charging signal
                 None,  # empty CST
                 TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
-            # TODO compare expected values
-            assert result is not None
+            assert result["commodity_costs_eur_per_year"] == 20323.2
+            assert result["capacity_costs_eur"] == 7014
 
     def test_pv_nominal(self):
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -58,6 +58,8 @@ class TestSimulationCosts:
         assert sum(result["power_grid_supply_list"]) == 0
         # fix load: 0
         assert sum(result["power_fix_load_list"]) == 0
+        # feed in from local genration:
+        assert sum(result["power_generation_feed_in_list"]) == 0
         # charging signal: depends on schedule, should be all None
         assert not any(result["charging_signal_list"])
 

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -71,6 +71,7 @@ class TestSimulationCosts:
         timeseries_lists = [timeseries.get(k, [0]*s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
                             "fixed load [kW]", "generation feed-in [kW]",
+                            "V2G feed-in [kW]", "battery feed-in [kW]",
                             "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
@@ -119,6 +120,7 @@ class TestSimulationCosts:
             timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
                             "fixed load [kW]", "generation feed-in [kW]",
+                            "V2G feed-in [kW]", "battery feed-in [kW]",
                             "window signal [-]"]]
             price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
             pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -138,6 +140,7 @@ class TestSimulationCosts:
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                             "time", "grid supply [kW]", "price [EUR/kWh]",
                             "fixed load [kW]", "generation feed-in [kW]",
+                            "V2G feed-in [kW]", "battery feed-in [kW]",
                             "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
@@ -163,7 +166,9 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
                         "time", "grid supply [kW]", "price [EUR/kWh]",
-                        "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
+                        "fixed load [kW]", "generation feed-in [kW]",
+                        "V2G feed-in [kW]", "battery feed-in [kW]",
+                        "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -187,7 +192,9 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
+            "fixed load [kW]", "generation feed-in [kW]",
+            "V2G feed-in [kW]", "battery feed-in [kW]",
+            "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -212,7 +219,9 @@ class TestSimulationCosts:
         timeseries = s.GC1_timeseries
         timeseries_lists = [timeseries.get(k, [0] * s.n_intervals) for k in [
             "time", "grid supply [kW]", "price [EUR/kWh]",
-            "fixed load [kW]", "generation feed-in [kW]", "window signal [-]"]]
+            "fixed load [kW]", "generation feed-in [kW]",
+            "V2G feed-in [kW]", "battery feed-in [kW]",
+            "window signal [-]"]]
         price_sheet = TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json'
 
         pv = sum([pv.nominal_power for pv in s.components.photovoltaics.values()])
@@ -237,6 +246,8 @@ class TestSimulationCosts:
             None,  # empty prices
             [0] * 9,  # empty fix loads
             [0] * 9,  # empty feed-in from local generation
+            [0] * 9,  # empty feed-in from V2G
+            [0] * 9,  # empty feed-in from battery
             None,  # empty charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -252,6 +263,8 @@ class TestSimulationCosts:
                 [1]*9,  # static prices
                 [100] * 9,  # static fixed loads
                 [0] * 9,  # empty feed-in from local generation
+                [0] * 9,  # empty feed-in from V2G
+                [0] * 9,  # empty feed-in from battery
                 [True]*9,  # always-on charging signal
                 None,  # empty CST
                 TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json')
@@ -272,6 +285,8 @@ class TestSimulationCosts:
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
                 [0] * 9,  # empty feed-in from local generation
+                [0] * 9,  # empty feed-in from V2G
+                [0] * 9,  # empty feed-in from battery
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -287,6 +302,8 @@ class TestSimulationCosts:
                 None,  # empty prices
                 [0] * 9,  # empty fixed loads
                 [0] * 9,  # empty feed-in from local generation
+                [0] * 9,  # empty feed-in from V2G
+                [0] * 9,  # empty feed-in from battery
                 None,  # no charging signal
                 None,  # empty CST
                 price_sheet,
@@ -302,6 +319,8 @@ class TestSimulationCosts:
             None,  # empty prices
             [0] * 9,  # empty fixed loads
             [0] * 9,  # empty feed-in from local generation
+            [0] * 9,  # empty feed-in from V2G
+            [0] * 9,  # empty feed-in from battery
             None,  # no charging signal
             None,  # empty CST
             TEST_REPO_PATH / 'test_data/input_test_cost_calculation/price_sheet.json',

--- a/tests/test_data/input_test_cost_calculation/price_sheet.json
+++ b/tests/test_data/input_test_cost_calculation/price_sheet.json
@@ -99,6 +99,7 @@
             "remuneration": [6.24, 6.06, 4.74]
         },
         "V2G": 0,
+        "battery": 0,
         "unit": "ct/kWh",
         "info": "remuneration for power fed into the grid by PV power plants or electric vehicles"
     },

--- a/tests/test_data/input_test_strategies/scenario_B.json
+++ b/tests/test_data/input_test_strategies/scenario_B.json
@@ -141,7 +141,7 @@
       }
     },
     "local_generation": {
-      "PV_final_zeros": {
+      "PV_DHL_final_zeros": {
         "csv_file": "example_pv_feedin.csv",
         "start_time": "2018-01-01T00:00:00+02:00",
         "step_duration_s": 3600,

--- a/tests/test_data/input_test_strategies/scenario_B.json
+++ b/tests/test_data/input_test_strategies/scenario_B.json
@@ -101,6 +101,12 @@
           ]
         ]
       }
+    },
+    "photovoltaics": {
+      "PV1": {
+        "parent": "GC1",
+        "nominal_power": 100
+      }
     }
   },
   "events": {
@@ -135,7 +141,7 @@
       }
     },
     "local_generation": {
-      "PV_DHL_final_zeros": {
+      "PV_final_zeros": {
         "csv_file": "example_pv_feedin.csv",
         "start_time": "2018-01-01T00:00:00+02:00",
         "step_duration_s": 3600,

--- a/tests/test_data/input_test_strategies/scenario_PV_Bat.json
+++ b/tests/test_data/input_test_strategies/scenario_PV_Bat.json
@@ -83,7 +83,7 @@
     "grid_operator_signals": [],
     "fixed_load": {},
     "local_generation": {
-      "PV_feed-in": {
+      "PV_feed-in_KM": {
         "start_time": "2022-04-04T00:00:00+02:00",
         "step_duration_s": 3600,
         "grid_connector_id": "GC1",

--- a/tests/test_data/input_test_strategies/scenario_PV_Bat.json
+++ b/tests/test_data/input_test_strategies/scenario_PV_Bat.json
@@ -83,7 +83,7 @@
     "grid_operator_signals": [],
     "fixed_load": {},
     "local_generation": {
-      "PV_feed-in_KM": {
+      "PV_feed-in": {
         "start_time": "2022-04-04T00:00:00+02:00",
         "step_duration_s": 3600,
         "grid_connector_id": "GC1",


### PR DESCRIPTION
Fixes #Issue

**Changes proposed in this pull request**:
- change calculation of feed-in remuneration for PV energy by using PV feed-in energy instead of total feed-in energy which includes V2G and Battery feed-in, too

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`

Also the following steps were realized (if applies):
- [x] Write docstrings to your code (adjust docstrings)
- [ ] Explain new functionalities in readthedocs
- [x] Write test(s) for new patch of code (ajdust tests)
- [x] Check building of documentation with `doc/make html`
