### PR TITLE
take actual grid supply for cost calculation of fixed load

### DIFF
--- a/calculate_costs.py
+++ b/calculate_costs.py
@@ -33,8 +33,11 @@ def read_simulation_csv(csv_file):
             # find values for parameter
             timestamp = datetime.datetime.fromisoformat(row["time"])
             price = float(row.get("price [EUR/kWh]", 0))
-            power_grid_supply = float(row["grid supply [kW]"])
-            power_fix_load = float(row["fixed load [kW]"])
+            power_grid_supply = float(row.get("grid supply [kW]", 0))
+            power_fix_load = max(float(row.get("fixed load [kW]", 0)) +
+                                 min(float(row.get("local generation [kW]", 0)), 0) +
+                                 min(float(row.get("battery power [kW]", 0)), 0) +
+                                 min(float(row.get("sum CS power [kW]", 0)), 0), 0)
             power_generation_feed_in = float(row.get("generation feed-in [kW]", 0))
             power_v2g_feed_in = float(row.get("V2G feed-in [kW]", 0))
             power_battery_feed_in = float(row.get("battery feed-in [kW]", 0))

--- a/tests/test_calculate_costs.py
+++ b/tests/test_calculate_costs.py
@@ -103,7 +103,7 @@ class TestSimulationCosts:
         scenarios = {
             "scenario_A.json": [2522.67, 776.54, 65.7, 799.38, 881.06, 0.0],
             "scenario_B.json": [21798.48, 6899.86, 65.7, 7102.8, 7730.12, 0.0],
-            "scenario_C1.json": [3045.54, 942.64, 65.7, 970.36, 1066.84, 0.0],
+            "scenario_C1.json": [22086.7, 6991.42, 65.7, 7197.05, 7832.53, 0.0],
             "scenario_C2.json": [2792.23, 862.17, 65.7, 887.53, 976.85, 0.0],
             "scenario_C3.json": [1887.55, 574.78, 65.7, 591.68, 655.39, 0.0],
             # "bus_scenario_D.json": [0,0,0,0,0,0],  # buggy: can't charge enough
@@ -229,11 +229,11 @@ class TestSimulationCosts:
         # check returned values
         result = cc.calculate_costs("balanced_market", "MV", s.interval, *timeseries_lists,
                                     str(price_sheet), None, pv)
-        assert result["total_costs_per_year"] == 495.31
-        assert result["commodity_costs_eur_per_year"] == 22.08
-        assert result["capacity_costs_eur"] == 0
-        assert result["power_procurement_costs_per_year"] == 246.6
-        assert result["levies_fees_and_taxes_per_year"] == 226.63
+        assert result["total_costs_per_year"] == 24339.52
+        assert result["commodity_costs_eur_per_year"] == 4523.5
+        assert result["capacity_costs_eur"] == 4426.75
+        assert result["power_procurement_costs_per_year"] == 7197.05
+        assert result["levies_fees_and_taxes_per_year"] == 8192.22
         assert result["feed_in_remuneration_per_year"] == 0
 
     def test_calculate_costs_schedule_C(self, tmp_path):

--- a/tests/test_data/input_test_strategies/scenario_A.json
+++ b/tests/test_data/input_test_strategies/scenario_A.json
@@ -124,8 +124,6 @@
         }
       }
     ],
-    "fixed_load": {},
-    "energy_feed_in": {},
     "vehicle_events": [
       {
         "signal_time": "2018-01-01T08:47:00+02:00",

--- a/tests/test_data/input_test_strategies/scenario_C1.json
+++ b/tests/test_data/input_test_strategies/scenario_C1.json
@@ -125,6 +125,26 @@
         }
       }
     ],
+    "fixed_load": {
+      "building": {
+        "csv_file": "example_load.csv",
+        "start_time": "2018-01-01T00:00:00+02:00",
+        "step_duration_s": 600,
+        "grid_connector_id": "GC1",
+        "column": "value",
+        "factor": 0.001
+      }
+    },
+    "local_generation": {
+      "example_pv": {
+        "csv_file": "example_pv.csv",
+        "start_time": "2018-01-01T00:00:00+02:00",
+        "step_duration_s": 3600,
+        "grid_connector_id": "GC1",
+        "column": "pv (kW)",
+        "factor": 1
+      }
+    },
     "vehicle_events": [
       {
         "signal_time": "2018-01-01T08:00:00+02:00",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -303,14 +303,14 @@ class TestScenarios(TestCaseBase):
 
         assert s.testing["avg_total_standing_time"]["GC1"] == 17.75
         assert s.testing["avg_stand_time"]["GC1"] == 8.875
-        assert round(s.testing["avg_needed_energy"]["GC1"], 2) == 1.08
-        assert round(s.testing["avg_drawn_power"]["GC1"], 2) == 1.44
-        assert round(s.testing["sum_local_generation_per_h"]["GC1"], 2) == 0
-        assert round(s.testing["vehicle_battery_cycles"]["GC1"], 2) == 1.1
+        assert round(s.testing["avg_needed_energy"]["GC1"], 2) == 0.73
+        assert round(s.testing["avg_drawn_power"]["GC1"], 2) == 10.67
+        assert round(s.testing["sum_local_generation_per_h"]["GC1"], 2) == 347.59
+        assert round(s.testing["vehicle_battery_cycles"]["GC1"], 2) == 1.41
         assert round(s.testing["avg_flex_per_window"]["GC1"][0], 2) == 372
-        assert round(s.testing["avg_flex_per_window"]["GC1"][3], 2) == 375.71
-        assert round(s.testing["sum_energy_per_window"]["GC1"][0], 2) == 0
-        assert round(s.testing["sum_energy_per_window"]["GC1"][3], 2) == 0
+        assert round(s.testing["avg_flex_per_window"]["GC1"][3], 2) == 375.09
+        assert round(s.testing["sum_energy_per_window"]["GC1"][0], 2) == 215.87
+        assert round(s.testing["sum_energy_per_window"]["GC1"][3], 2) == 40.21
         load = [0] * 96
         for key, values in s.testing["timeseries"]["loads"]["GC1"].items():
             load = [a + b for a, b in zip(load, values)]
@@ -322,7 +322,7 @@ class TestScenarios(TestCaseBase):
         assert s.testing["max_total_load"] > 0
 
     def test_flex_window_all_loaded_in_windows(self):
-        input = TEST_REPO_PATH / 'test_data/input_test_strategies/scenario_C1.json'
+        input = TEST_REPO_PATH / 'test_data/input_test_strategies/scenario_C2.json'
         s = scenario.Scenario(load_json(input), input.parent)
         s.run('flex_window', {"testing": True})
 


### PR DESCRIPTION
**Changes proposed in this pull request**:
- only take actual grid supply for cost calculation of fixed load instead of original fixed load

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] Explain new functionalities in readthedocs
- [ ] Write test(s) for new patch of code
- [x] Check building of documentation with `doc/make html`
