### PR TITLE
Fix v2g discharge power in balanced_market

### DIFF
--- a/spice_ev/strategies/balanced_market.py
+++ b/spice_ev/strategies/balanced_market.py
@@ -236,7 +236,8 @@ class BalancedMarket(Strategy):
 
                 gc_cur_discharge_power_limit = (timesteps[v2g_ts_idx]["power"]
                                                 - 2*timesteps[v2g_ts_idx]["max_power"])
-                p = min(max(gc_cur_discharge_power_limit, p), 0)
+                cs_cur_discharge_power_limit = timesteps[v2g_ts_idx]["power"] - 2*cs.max_power
+                p = min(max(gc_cur_discharge_power_limit, cs_cur_discharge_power_limit, p), 0)
                 power[v2g_ts_idx] = p
 
                 if v2g_ts_idx == 0:

--- a/spice_ev/strategies/balanced_market.py
+++ b/spice_ev/strategies/balanced_market.py
@@ -236,7 +236,7 @@ class BalancedMarket(Strategy):
 
                 gc_cur_discharge_power_limit = (timesteps[v2g_ts_idx]["power"]
                                                 - 2*timesteps[v2g_ts_idx]["max_power"])
-                cs_cur_discharge_power_limit = timesteps[v2g_ts_idx]["power"] - 2*cs.max_power
+                cs_cur_discharge_power_limit = -(cs.max_power + cs.current_power)
                 p = min(max(gc_cur_discharge_power_limit, cs_cur_discharge_power_limit, p), 0)
                 power[v2g_ts_idx] = p
 


### PR DESCRIPTION
Fixes #175 

**Changes proposed in this pull request**:
- Discharge power for V2G in the balanced_market strategy now considers the charging station power

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`
- [ ] Add the description of your changes to the CHANGELOG.md in subsection with release name `## [Unreleased]` and state the PR number with `#`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] Explain new functionalities in readthedocs
- [ ] Write test(s) for new patch of code
- [ ] Check building of documentation with `doc/make html`
