### PR TITLE
Feature/plotting windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Template:
 - [(#)]()
 ```
 
+## [1.0.2] - Unreleased - 2023-08-21
+
+### Changed
+- plotting time windows with shaded backgrounds
+
 ## [1.0.1] - Minor Fixes - 2023-08-04
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="spice_ev",
-    version="1.0.1",
+    version="1.0.2",
     description="Simulation Program for Individual Charging Events of Electric Vehicles.",
     url="https://github.com/rl-institut/spice_ev",
     author="Reiner Lemoine Institut",

--- a/spice_ev/report.py
+++ b/spice_ev/report.py
@@ -700,22 +700,27 @@ def plot(scenario):
     if scenario.strat.uses_window:
         # get list with boolean values for timesteps inside/outside window for each grid connector
         for gcID, w_list in scenario.gcWindowSchedule.items():
-            if all(s is not None for s in w_list):
-                # add shaded background based on the boolean values
-                color = 'red' if w_list[0] else 'lightgreen'
-                # add only one label for each type of time window
-                i = 0
-                window_label = ('_'*i+'Inside window') if w_list[0] else ("_"*i+"Outside window")
-                start_date = xlabels[0]
-                for date, v in zip(xlabels[0:], w_list[0:]):
-                    if v != w_list[xlabels.index(start_date)]:
-                        ax.axvspan(start_date, date, label=window_label, facecolor=color, alpha=0.2)
-                        start_date = date
-                        color = 'red' if v else 'lightgreen'
-                        window_label = ('_'*i+'Inside window') if v else ("_"*i+"Outside window")
-                        i += 1
-                # handle the last window if it extends to the end
-                ax.axvspan(start_date, xlabels[-1], label=window_label, facecolor=color, alpha=0.2)
+            # add shaded background based on the boolean values, no background if no values
+            start_idx = 0
+            # show each label only once
+            label_shown = [False, False]
+            for i in range(scenario.n_intervals):
+                if w_list[i] != w_list[start_idx] or i == (scenario.n_intervals-1):
+                    # window value changed or end of scenario: plot new interval
+                    window = w_list[start_idx]
+                    if window is not None:
+                        color = 'red' if window else 'lightgreen'
+                        label = 'Inside window' if window else 'Outside window'
+                        if label_shown[window]:
+                            # labels starting with underscores are ignored
+                            label = '_' + label
+                        else:
+                            # show label once, then set flag
+                            label_shown[window] = True
+                        # draw colored rectangle for window
+                        ax.axvspan(xlabels[start_idx], xlabels[i], label=label, facecolor=color,
+                                   alpha=0.2)
+                        start_idx = i
     # draw schedule
     if scenario.strat.uses_schedule:
         for gcID, schedule in scenario.gcPowerSchedule.items():

--- a/spice_ev/report.py
+++ b/spice_ev/report.py
@@ -651,19 +651,19 @@ def plot(scenario):
     for r in scenario.results:
         xlabels.append(r['current_time'])
 
-    # batteries
+    # plot stationary batteries
     if scenario.batteryLevels:
         plots_top_row = 3
         ax = plt.subplot(2, plots_top_row, 3)
         ax.set_title('Stationary Batteries')
-        ax.set(ylabel='Stored Power in kWh')
+        ax.set(ylabel='Stored power in kWh')
         for name, values in scenario.batteryLevels.items():
             ax.plot(xlabels, values, label=name)
         ax.legend()
     else:
         plots_top_row = 2
 
-    # vehicles
+    # plot vehicles
     ax = plt.subplot(2, plots_top_row, 1)
     ax.set_title('Vehicles')
     ax.set(ylabel='SoC')
@@ -676,7 +676,7 @@ def plot(scenario):
         if len(scenario.components.vehicles) <= 10:
             ax.legend(lines, sorted(scenario.components.vehicles.keys()))
 
-    # charging stations
+    # plot charging stations
     ax = plt.subplot(2, plots_top_row, 2)
     ax.set_title('Charging Stations')
     ax.set(ylabel='Power in kW')
@@ -685,35 +685,50 @@ def plot(scenario):
         if len(scenario.components.charging_stations) <= 10:
             ax.legend(lines, sorted(scenario.components.charging_stations.keys()))
 
-    # total power
+    # plot all power sources
     ax = plt.subplot(2, 2, 3)
+    # charging stations
     if any(scenario.sum_cs):
         ax.step(xlabels, list([sum(cs) for cs in scenario.sum_cs]),
                 label="Charging Stations", where='post')
+    # other loads
     gc_ids = scenario.components.grid_connectors.keys()
     for gcID in gc_ids:
         for name, values in scenario.loads[gcID].items():
             ax.step(xlabels, values, label=name, where='post')
-    # draw schedule
+    # draw time windows
     if scenario.strat.uses_window:
-        for gcID, schedule in scenario.gcWindowSchedule.items():
-            if all(s is not None for s in schedule):
-                # schedule exists
-                window_values = [v * int(max(scenario.totalLoad[gcID])) for v in schedule]
-                ax.step(xlabels, window_values, label="window {}".format(gcID),
-                        linestyle='--', where='post')
+        # get list with boolean values for timesteps inside/outside window for each grid connector
+        for gcID, w_list in scenario.gcWindowSchedule.items():
+            if all(s is not None for s in w_list):
+                # add shaded background based on the boolean values
+                color = 'red' if w_list[0] else 'lightgreen'
+                # add only one label for each type of time window
+                i = 0
+                window_label = ('_'*i+'Inside window') if w_list[0] else ("_"*i+"Outside window")
+                start_date = xlabels[0]
+                for date, v in zip(xlabels[0:], w_list[0:]):
+                    if v != w_list[xlabels.index(start_date)]:
+                        ax.axvspan(start_date, date, label=window_label, facecolor=color, alpha=0.2)
+                        start_date = date
+                        color = 'red' if v else 'lightgreen'
+                        window_label = ('_'*i+'Inside window') if v else ("_"*i+"Outside window")
+                        i += 1
+                # handle the last window if it extends to the end
+                ax.axvspan(start_date, xlabels[-1], label=window_label, facecolor=color, alpha=0.2)
+    # draw schedule
     if scenario.strat.uses_schedule:
         for gcID, schedule in scenario.gcPowerSchedule.items():
             if any(s is not None for s in schedule):
                 ax.step(xlabels, schedule, label="Schedule {}".format(gcID), where='post')
-
+    # total power
     ax.step(xlabels, scenario.all_totalLoad, label="Total", where='post')
     ax.set_title('Total Power')
     ax.set(ylabel='Power in kW')
     ax.legend()
     ax.xaxis_date()  # xaxis are datetime objects
 
-    # price
+    # plot prices
     ax = plt.subplot(2, 2, 4)
     prices = list(zip(*scenario.prices.values()))
     lines = ax.step(xlabels, prices, where='post')

--- a/spice_ev/strategies/flex_window.py
+++ b/spice_ev/strategies/flex_window.py
@@ -15,6 +15,7 @@ class FlexWindow(Strategy):
         assert (len(self.world_state.grid_connectors) == 1), "Only one grid connector supported"
         self.description = "Flex Window ({}, {} hour horizon)".format(
             self.LOAD_STRAT, self.HORIZON)
+        self.uses_window = True
 
         if self.LOAD_STRAT == "greedy":
             # charge vehicles in need first, then by order of departure


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Plotting time windows as shaded backgrounds (in anticipation of this [branch](https://github.com/rl-institut/spice_ev/tree/refactor/peak_load_window))
- Plot time windows of strategy flex_window (wrong order, but flex_window will be refactored)

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`
- [x] Add the description of your changes to the CHANGELOG.md in subsection with release name `## [Unreleased]` and state the PR number with `#`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] Explain new functionalities in readthedocs
- [ ] Write test(s) for new patch of code
- [x] Check building of documentation with `doc/make html`
