### PR TITLE
fix battery problems at CC boundaries

### DIFF
--- a/spice_ev/battery.py
+++ b/spice_ev/battery.py
@@ -280,6 +280,10 @@ class Battery():
             dx = x2 - x1
             dy = y2 - y1
 
+            if y1 == y2 == 0:
+                # no energy in current linear section: stop charging
+                break
+
             m = dy / dx
             n = y1 - m * x1
             c = self.capacity

--- a/spice_ev/battery.py
+++ b/spice_ev/battery.py
@@ -255,10 +255,10 @@ class Battery():
         # compute average power for each linear section
         # update SOC
         # computes for whole time or until target is reached
-        while remaining_hours > self.EPS and sign * (target_soc - self.soc) > 0:
+        while remaining_hours > self.EPS and sign * (target_soc - self.soc) > self.EPS:
             # target soc not yet reached
             # charging: self.soc < target; discharging: self.soc > target
-            while sign * (boundary_soc - self.soc) <= 0:
+            while sign * (boundary_soc - self.soc) < self.EPS:
                 # soc outside current boundary, get next section
                 # charging: self.soc >= boundary_soc; discharging: self.soc <= boundary_soc
                 boundary_idx += sign
@@ -313,6 +313,7 @@ class Battery():
                 assert new_soc >= self.soc, f"Charge: {new_soc} should be greater than {self.soc}"
 
             energy_delta = abs(new_soc - self.soc) * c
+            assert energy_delta > 0
             self.soc = new_soc
             remaining_hours -= abs(t)
             # remember amount of energy loaded into battery

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -273,3 +273,10 @@ class TestBattery:
         b.soc = 0.8981399672579304
         p = b.load(td, target_power=target_power)['avg_power']
         assert pytest.approx(p) == target_power
+
+        # third test: charging curve is zero => no charging
+        lc = loading_curve.LoadingCurve([(0, 0.0), (0.8, 0.0), (1, 0.0)])
+        b = battery.Battery(350, lc, 0.8)
+        td = datetime.timedelta(minutes=15)
+        p = b.load(td)["avg_power"]
+        assert p == 0


### PR DESCRIPTION
In certain cases, the battery Soc approached the charging curve boundary without being able to surpass it (floating point arithmetic). 
Changed: take next interval if SoC is already close to next boundary, stop charging if SoC is close to target (in both cases compare with EPS instead of 0).
Added assertion that energy delta is greater than 0 (something happens in the battery, no infinite loop)
