### PR TITLE
cost calculation for strategy peak_load_window

### DIFF
--- a/doc/source/charging_strategies_incentives.rst
+++ b/doc/source/charging_strategies_incentives.rst
@@ -64,13 +64,13 @@ Two different sub-strategies can be used:
 
 Peak load window
 ----------------
-Given a time window of high load, this strategy tries to charge outside of this window. Different sub-strategies are
-supported:
-
-- Greedy: The vehicles charge as much as possible, one after the other (vehicles below desired SOC charge first).
-- Needy: The power is allocated according to the missing power needed to reach the desired SOC.
-- Balanced: The power is distributed evenly among the vehicles below the desired SOC. Surplus is then distributed evenly
-  among all vehicles.
+Given time windows of high load, this strategy tries to charge outside of these windows. The time windows are given in
+the JSON `examples/data/time_windows.json`. In a first step the peak power inside these time windows is calculated.
+Usually this peak power is set by a fix load at the grid connector (e.g. a load from the building). If there are no
+fix loads, the peak power is set to zero.
+The strategy tries to draw power outside the windows, using a balanced approach.
+Inside the time windows the consumers like electriv vehicles or stationary batteries can draw power up to the peak power.
+If this energy is not sufficient, a peak shaving algorithm tries to keep the peak power as low as possible.
 
 Flex Window
 -----------
@@ -121,7 +121,7 @@ The following table gives an overview of the possible combinations.
 +--------------------------+-----------------------------+-------------------------------+-------------------------------+-------------------------------+
 | Schedule                 | x                           |                               |                               | x                             |
 +--------------------------+-----------------------------+-------------------------------+-------------------------------+-------------------------------+
-| Peak load window         | x                           |                               |  x                            |                               |
+| Peak load window         | x                           |                               |                               |                               |
 +--------------------------+-----------------------------+-------------------------------+-------------------------------+-------------------------------+
 | Flex window              | x                           |                               |  x                            |                               |
 +--------------------------+-----------------------------+-------------------------------+-------------------------------+-------------------------------+
@@ -141,7 +141,6 @@ fees are only applied on them. Fixed loads are charged according to the state of
 
 State of the art
 ----------------
-
 Today a commodity charge is applied on the amount of electrical energy supplied from the grid. Additionally SLP
 customers (standard load profile) have to pay a fixed basic charge per year. RLM customers (consumption metering) pay a
 capacity charge instead which is multiplied with the maximum power supplied at the grid connector in one year. Depending
@@ -165,7 +164,6 @@ friendly charging is used.
 
 Flexible time windows
 ---------------------
-
 Based on the forecast grid situation, low tariff windows and high tariff windows are defined. If curtailment of
 renewable power plants is forecast or local generation outweighs load, these periods become low tariff windows.
 
@@ -177,7 +175,6 @@ is encouraged.
 
 Schedule-based grid fees
 ------------------------
-
 Similar to the flexible time windows, the tariff for grid friendly charging is applied on the flexible loads such as
 electric vehicles when using schedule-based grid fees. However, a capacity charge is not applied on the flexible load.
 Instead, the deviation of the total load from the schedule is charged. Taking a deviation tolerance into account, a

--- a/doc/source/charging_strategies_incentives.rst
+++ b/doc/source/charging_strategies_incentives.rst
@@ -64,12 +64,12 @@ Two different sub-strategies can be used:
 
 Peak load window
 ----------------
-Given time windows of high load, this strategy tries to charge outside of these windows. The time windows are given in
-the JSON `examples/data/time_windows.json`. In a first step the peak power inside these time windows is calculated.
-Usually this peak power is set by a fix load at the grid connector (e.g. a load from the building). If there are no
-fix loads, the peak power is set to zero.
+Given time windows of high load, this strategy tries to charge outside of these windows. The example time windows are
+given in the JSON `examples/data/time_windows.json`. In a first step the peak power inside these time windows is calculated.
+Usually this peak power is set by a fixed load at the grid connector (e.g. a load from the building). If there are no
+fixed loads, the peak power is set to zero.
 The strategy tries to draw power outside the windows, using a balanced approach.
-Inside the time windows the consumers like electriv vehicles or stationary batteries can draw power up to the peak power.
+Inside time windows, consumers like electric vehicles or stationary batteries can draw power up to the peak power.
 If this energy is not sufficient, a peak shaving algorithm tries to keep the peak power as low as possible.
 
 Flex Window

--- a/doc/source/code.rst
+++ b/doc/source/code.rst
@@ -214,7 +214,7 @@ are supported.
 
     PeakLoadWindow
     PeakLoadWindow.step
-    PeakLoadWindow.distribute_power
+    PeakLoadWindow.step_gc
 
 
 Schedule

--- a/doc/source/simulating_with_spiceev.rst
+++ b/doc/source/simulating_with_spiceev.rst
@@ -205,21 +205,19 @@ stationary batteries or V2G, you need to set the target SOC parameter of the bat
 **Strategy options**
 
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
-    | **Strategy option** | **Default**                |              **Explanation**                            | **Greedy**  | **Balanced** | **Balanced Market** | **Schedule** | **Peak load window**| **Flex window**  | **Distributed** |
+    | **Strategy option** | **Default**                |              **Explanation**                            | **Greedy**  | **Balanced** | **Balanced Market** | **Schedule** | **Peak Load Window**| **Flex Window**  | **Distributed** |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
     |   CONCURRENCY       |     1.0                    | Reduce maximum available power at each charging station.| x           |              | x                   |              |                     | x                |                 |
     |                     |                            |                                                         |             |              |                     |              |                     |                  |                 |
     |                     |                            | A value of 0.5 means only half the power is available.  |             |              |                     |              |                     |                  |                 |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
-    |   PRICE_THRESHOLD   |    0.001                   | A price below this is considered cheap. Unit: € / 1 kWh | x           | x            | x                   |              |                     | x                | x               |
-    +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
-    |   ITERATIONS        |     12                     | Minimum depth of binary search to find charging power   |             | x            |                     |              |                     |                  |                 |
+    |   PRICE_THRESHOLD   |    0.001                   | A price below this is considered cheap. Unit: EUR/kWh   | x           | x            | x                   |              |                     | x                | x               |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
     |   HORIZON           |      24                    | number of hours to look ahead                           |             |              | x                   |              |                     | x                |                 |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
     |   DISCHARGE_LIMIT   |      0                     | V2G: maximum depth of discharge [0-1]                   |             |              | x                   |              |                     | x                | x               |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
-    | V2G_POWER_FACTOR    |      1                     | Fraction of max battery power used for discharge        |             |              | x                   |              |                     | x                |                 |
+    | V2G_POWER_FACTOR    |      1                     | Fraction of max battery power used for discharge        |             |              | x                   |              |                     | x                | x               |
     |                     |                            | process [0-1]                                           |             |              |                     |              |                     |                  |                 |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
     | ALLOW_NEGATIVE_SOC  |   False                    | simulation does not abort if SOC becomes negative       |             |              |                     |              |                     |                  | x               |
@@ -228,14 +226,9 @@ stationary batteries or V2G, you need to set the target SOC parameter of the bat
     |                     |                            |                                                         |             |              |                     |              |                     |                  |                 |
     |                     |                            | is limited                                              |             |              |                     |              |                     |                  |                 |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
-    |  V2G_POWER_FACTOR   |      1                     | Fraction of max battery power used for discharge        |             |              |                     |              |                     |                  | x               |
-    |                     |                            | process [0-1]                                           |             |              |                     |              |                     |                  |                 |
-    +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
     |   LOAD_STRAT        |  Flex window: "balanced"   | Sub-strategies for behaviour within charging windows    |             |              |                     | x            | x                   | x                |                 |
     |                     |                            |                                                         |             |              |                     |              |                     |                  |                 |
     |                     |  Schedule: "collective"    | (see description above for options and explanations)    |             |              |                     |              |                     |                  |                 |
-    |                     |                            |                                                         |             |              |                     |              |                     |                  |                 |
-    |                     |  Peak load window: "needy" |                                                         |             |              |                     |              |                     |                  |                 |
     +---------------------+----------------------------+---------------------------------------------------------+-------------+--------------+---------------------+--------------+---------------------+------------------+-----------------+
 
 
@@ -250,7 +243,7 @@ input is part of the repository, as some data is classified and/or should be cre
 generate.py
 -----------
 
-**Input for mode `statistics` and `simbev`**
+**Input for mode STATISTICS and SIMBEV**
 
 - Fixed load (CSV): This file needs one column with the drawn power in kW (can have more columns, but only one is
   relevant). The file is read line-by-line, with events starting at start_time and updating every interval
@@ -263,13 +256,13 @@ generate.py
   (configurable).
 - Configuration (CFG): Refer to `generate_from_statistics.cfg` and `generate_from_simbev.cfg` in the`examples` folder.
 
-**Output for mode `statistics` and `simbev`**
+**Output for mode STATISTICS and SIMBEV**
 
 - Scenario (JSON): This file is used in `simulate.py`. It defines the general information (start_time, interval,
   n_intervals), components (vehicle types, vehicles, grid connectors, charging stations, batteries) and events (fixed
   loads, local generation, grid operator signals and vehicle events).
 
-**Input for mode `csv`**
+**Input for mode CSV**
 
 - Trips schedule (CSV): Each row in the CSV file represents one trip. The following columns are needed: "departure_time"
   (datetime), "arrival_time" (datetime), "vehicle_type" (str), "soc" (numeric) / "delta_soc" (numeric) / "distance"
@@ -277,7 +270,7 @@ generate.py
 - Configuration (CFG): Refer to `generate_from_csv.cfg` in the `examples` folder or the `generate_from_csv_template.csv`
   in the subfolder `data`.
 
-**Output for mode `csv`**
+**Output for mode CSV**
 
 - Scenario (JSON): This file is used in `simulate.py`. It defines the general information (start_time, interval,
   n_intervals), components (vehicle types, vehicles, grid connectors, charging stations, batteries) and events (fixed

--- a/examples/data/price_sheet.json
+++ b/examples/data/price_sheet.json
@@ -103,7 +103,21 @@
         "unit": "ct/kWh",
         "info": "remuneration for power fed into the grid by PV power plants or electric vehicles"
     },
-    "strategy_related_cost_parameters": {
+    "strategy_related": {
+        "peak_load_window": {
+            "significance_threshold": {
+                "eHV": 5,
+                "eHV/HV": 10,
+                "HV": 10,
+                "HV/MV": 20,
+                "MV": 20,
+                "MV/LV": 30,
+                "LV": 30,
+                "unit": "%",
+                "info": ["significance threshold between overall peak power and peak power ",
+                    "inside time window to see if cost calculation for strategy can be applied"]
+            }
+        },
         "balanced_market": {
             "low_tariff_factor": 0.68,
             "medium_tariff_factor": 1,

--- a/examples/data/price_sheet.json
+++ b/examples/data/price_sheet.json
@@ -23,9 +23,7 @@
                     "MV/LV": 44.26,
                     "LV": 44.26,
                     "unit": "EUR/(kW*a)",
-                    "info": ["capacity charge depending on the voltage level for RLM",
-                        "(Registrierende Leistungsmessung, engl.: consumption metering) customers with",
-                        "annual utilization time < 2500 h/a"]
+                    "info": "capacity charge depending on the voltage level for RLM (Registrierende Leistungsmessung, engl.: consumption metering) customers with annual utilization time < 2500 h/a"
                 },
                 "commodity_charge_ct/kWh": {
                     "HV": 2.3,
@@ -34,9 +32,7 @@
                     "MV/LV": 4.39,
                     "LV": 4.83,
                     "unit": "ct/kWh",
-                    "info": ["commodity charge depending on the voltage level for RLM",
-                        "(Registrierende Leistungsmessung, engl.: consumption metering) customers with",
-                        "annual utilization time < 2500 h/a"]
+                    "info": "commodity charge depending on the voltage level for RLM (Registrierende Leistungsmessung, engl.: consumption metering) customers with annual utilization time < 2500 h/a"
                 }
             },
             ">=2500_h/a": {
@@ -47,8 +43,7 @@
                     "MV/LV": 97.01,
                     "LV": 64.33,
                     "unit": "EUR/(kW*a)",
-                    "info": ["capacity charge depending on the voltage level for RLM customers with",
-                        "annual utilization time >= 2500 h/a"]
+                    "info": "capacity charge depending on the voltage level for RLM customers with annual utilization time >= 2500 h/a"
                 },
                 "commodity_charge_ct/kWh": {
                     "HV": 0.81,
@@ -57,8 +52,7 @@
                     "MV/LV": 2.28,
                     "LV": 4.03,
                     "unit": "ct/kWh",
-                    "info": ["commodity charge depending on the voltage level for RLM customers with",
-                        "annual utilization time >= 2500 h/a"]
+                    "info": "commodity charge depending on the voltage level for RLM customers with annual utilization time >= 2500 h/a"
                 }
             },
             "additional_costs": {
@@ -80,7 +74,7 @@
         "offshore_levy": 0.419,
         "interruptible_loads_levy": 0.003,
         "unit": "ct/kWh",
-        "info": ["levies on energy supplied from the power grid"]
+        "info": "levies on energy supplied from the power grid"
     },
     "concession_fee": {
         "charge": 1.32,
@@ -114,25 +108,21 @@
                 "MV/LV": 30,
                 "LV": 30,
                 "unit": "%",
-                "info": ["significance threshold between overall peak power and peak power ",
-                    "inside time window to see if cost calculation for strategy can be applied"]
+                "info": "significance threshold between overall peak power and peak power inside time window to see if cost calculation for strategy can be applied"
             }
         },
         "balanced_market": {
             "low_tariff_factor": 0.68,
             "medium_tariff_factor": 1,
             "unit": "-",
-            "info": ["factor sets commodity charge for low and medium tariff window by being multiplied with the ",
-                "commodity charge in the price sheet"]
+            "info": "factor sets commodity charge for low and medium tariff window by being multiplied with the commodity charge in the price sheet"
         },
         "schedule": {
             "reduction_of_commodity_charge": 0,
             "deviation_charge": 70.14,
             "deviation_tolerance": 0.1,
             "unit": "ct/kWh (reduction_of_commodity_charge), EUR/(kW*a) (deviation_charge), - (deviation_tolerance)",
-            "info": ["'reduction of commodity charge' can be subtracted from commodity charge (reimburse flexibility), ",
-                "'deviation charge' is applied on deviations from schedule, 'deviation_tolerance' is multiplied with ",
-                "the schedule power and defines the lower limit from which a deviation is to be charged"]
+            "info": "'reduction of commodity charge' can be subtracted from commodity charge (reimburse flexibility), 'deviation charge' is applied on deviations from schedule, 'deviation_tolerance' is multiplied with the schedule power and defines the lower limit from which a deviation is to be charged"
         }
     }
 }

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -231,7 +231,7 @@ def calculate_costs(strategy, voltage_level, interval,
         """
 
         # maximum power supplied from the grid:
-        max_power_grid_supply = max(power_grid_supply_list)
+        max_power_grid_supply = max(power_grid_supply_list + [0])
 
         if strategy == "peak_load_window":
             # get peak power inside time windows
@@ -296,7 +296,7 @@ def calculate_costs(strategy, voltage_level, interval,
         # COSTS FOR FIXED LOAD
 
         # maximum fixed power supplied from the grid [kW]:
-        max_power_grid_supply_fix = max(power_fix_load_list)
+        max_power_grid_supply_fix = max(power_fix_load_list + [0])
 
         if max_power_grid_supply_fix == 0:  # no fix load existing
             commodity_costs_eur_per_year_fix = 0
@@ -375,7 +375,7 @@ def calculate_costs(strategy, voltage_level, interval,
         # COSTS FOR FIXED LOAD
 
         # maximum fixed power supplied from the grid [kW]
-        max_power_grid_supply_fix = max(power_fix_load_list)
+        max_power_grid_supply_fix = max(power_fix_load_list + [0])
 
         if max_power_grid_supply_fix == 0:
             # no fix load existing
@@ -464,7 +464,7 @@ def calculate_costs(strategy, voltage_level, interval,
         # COSTS FOR FIXED LOAD
 
         # maximum fixed power supplied from the grid:
-        max_power_grid_supply_fix = max(power_fix_load_list)
+        max_power_grid_supply_fix = max(power_fix_load_list + [0])
 
         if max_power_grid_supply_fix == 0:
             # no fixed load existing

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -234,12 +234,9 @@ def calculate_costs(strategy, voltage_level, interval,
         max_power_grid_supply = max(power_grid_supply_list + [0])
 
         if strategy == "peak_load_window":
-            # get peak power inside time windows
+            # get peak power inside time windows (no time window: peak power is set to 0)
             window_loads = [l for (l, w) in zip(power_grid_supply_list, charging_signal_list) if w]
-            try:
-                peak_power_in_windows = max(window_loads)
-            except ValueError:
-                warnings.warn("No time windows found. Please provide time windows in extra file.")
+            peak_power_in_windows = max(window_loads + [0])
             # check if cost calculation for peak_load_window can be applied: significance_threshold
             significance_threshold = ((max_power_grid_supply - peak_power_in_windows) /
                                       max_power_grid_supply) * 100

--- a/spice_ev/costs.py
+++ b/spice_ev/costs.py
@@ -236,7 +236,10 @@ def calculate_costs(strategy, voltage_level, interval,
         if strategy == "peak_load_window":
             # get peak power inside time windows
             window_loads = [l for (l, w) in zip(power_grid_supply_list, charging_signal_list) if w]
-            peak_power_in_windows = max(window_loads)
+            try:
+                peak_power_in_windows = max(window_loads)
+            except ValueError:
+                warnings.warn("No time windows found. Please provide time windows in extra file.")
             # check if cost calculation for peak_load_window can be applied: significance_threshold
             significance_threshold = ((max_power_grid_supply - peak_power_in_windows) /
                                       max_power_grid_supply) * 100

--- a/spice_ev/report.py
+++ b/spice_ev/report.py
@@ -105,7 +105,7 @@ def aggregate_local_results(scenario, gcID):
     json_results["grid_connector"] = {
         "gcID": gcID,
         "voltage_level": scenario.components.grid_connectors[gcID].voltage_level
-        }
+    }
 
     pvs = scenario.components.photovoltaics.values()
     nominal_pv_power = sum([pv.nominal_power for pv in pvs if pv.parent == gcID])
@@ -124,7 +124,7 @@ def aggregate_local_results(scenario, gcID):
     # gather info about standing and power in specific time windows
     load_count = [[0] for _ in scenario.components.vehicles]
     load_window = [[] for _ in range(4)]
-    count_window = [[0]*len(scenario.components.vehicles) for _ in range(4)]
+    count_window = [[0] * len(scenario.components.vehicles) for _ in range(4)]
 
     cur_time = scenario.start_time - scenario.interval
     # maximum power (fixed and variable loads)
@@ -248,6 +248,19 @@ def aggregate_local_results(scenario, gcID):
                 " (averaged over all vehicles and charge events)"
     }
 
+    # data about power in time windows
+    if scenario.strategy_name == "peak_load_window":  # ToDo: Change to scenario.strat.uses_window
+        significance_threshold = ((max(scenario.totalLoad[gcID]) - scenario.strat.peak_power[gcID])
+                                  / max(scenario.totalLoad[gcID])) * 100
+        json_results["peak load time windows"] = {
+            "peak power in time windows": scenario.strat.peak_power[gcID],
+            "unit": "kW",
+            "significance threshold": significance_threshold,
+            "significance threshold from price sheet": "missing data: no cost calculation done",
+            "info": "Maximum drawn power inside time windows and "
+                    "significance threshold to check if cost model for strategy can be applied "
+        }
+
     # power peaks (fixed loads and variable loads)
     if any(scenario.totalLoad[gcID]):
         json_results["power peaks"] = {
@@ -305,7 +318,7 @@ def aggregate_local_results(scenario, gcID):
     total_bat_cap = 0
     for batID, battery in scenario.components.batteries.items():
         if scenario.components.batteries[batID].parent == gcID:
-            if battery.capacity > 2**63:
+            if battery.capacity > 2 ** 63:
                 # unlimited capacity
                 max_cap = max(scenario.batteryLevels[batID])
                 print("Battery {} is unlimited, set capacity to {} kWh".format(
@@ -458,6 +471,7 @@ def aggregate_timeseries(scenario, gcID):
     # any loads except CS present?
     hasFixedLoads = any(scenario.fixedLoads)
     hasSchedule = any(s is not None for s in scenario.gcPowerSchedule[gcID])
+    hasWindows = any(s is not None for s in scenario.gcWindowSchedule[gcID])
     hasGeneration = any(scenario.localGenerationPower[gcID])
     hasV2G = any([v.vehicle_type.v2g for v in scenario.components.vehicles.values()])
     hasBatteries = any([b.parent == gcID for b in scenario.components.batteries.values()])
@@ -485,7 +499,9 @@ def aggregate_timeseries(scenario, gcID):
     header += ["flex band min [kW]", "flex band base [kW]", "flex band max [kW]"]
     # schedule & window
     if hasSchedule:
-        header += ["schedule [kW]", "window signal [-]"]
+        header.append("schedule [kW]")
+    if hasWindows:
+        header.append("window signal [-]")
     # Feed-in to grid per asset
     header += [
         component for has, component in zip(
@@ -558,10 +574,9 @@ def aggregate_timeseries(scenario, gcID):
 
         # schedule + window schedule
         if hasSchedule:
-            row += [
-                round(scenario.gcPowerSchedule[gcID][idx], round_to_places),  # float
-                int(scenario.gcWindowSchedule[gcID][idx]),  # bool -> int
-            ]
+            row.append(round(scenario.gcPowerSchedule[gcID][idx], round_to_places))  # float
+        if hasWindows:
+            row.append(int(scenario.gcWindowSchedule[gcID][idx]))  # bool -> int
 
         # charging power
         # get sum of all current CS power that are connected to gc
@@ -715,7 +730,7 @@ def plot(scenario):
             # show each label only once
             label_shown = [gc_idx, gc_idx]
             for i in range(scenario.step_i):
-                if w_list[i] != w_list[start_idx] or i == (scenario.step_i-1):
+                if w_list[i] != w_list[start_idx] or i == (scenario.step_i - 1):
                     # window value changed or end of scenario: plot new interval
                     window = w_list[start_idx]
                     if window is not None:

--- a/spice_ev/strategies/peak_load_window.py
+++ b/spice_ev/strategies/peak_load_window.py
@@ -21,7 +21,7 @@ class PeakLoadWindow(Strategy):
         assert self.LOAD_STRAT in load_strats, (
             f"Unknown charging strategy '{self.LOAD_STRAT}'. Allowed: {', '.join(load_strats)}")
 
-        self.description = f"§19.2 StromNEV ({self.LOAD_STRAT})"
+        self.description = f"peak load window ({self.LOAD_STRAT})"
         self.uses_window = True
 
         if self.time_windows is None:

--- a/spice_ev/strategies/peak_load_window.py
+++ b/spice_ev/strategies/peak_load_window.py
@@ -12,6 +12,7 @@ class PeakLoadWindow(Strategy):
 
     Charge balanced outside of windows. Inside time windows different sub-strategies are possible.
     """
+
     def __init__(self, components, start_time, **kwargs):
         self.time_windows = None
         self.LOAD_STRAT = "greedy"  # peak_shaving or greedy
@@ -262,7 +263,7 @@ class PeakLoadWindow(Strategy):
                 avg_power = vehicle.battery.load(self.interval, target_power=p)["avg_power"]
                 return p, avg_power
 
-            power_levels = [0]*depart_idx
+            power_levels = [0] * depart_idx
             # try to charge balanced outside of load windows
             num_outside_ts = sum([not ts["window"] for ts in connected_ts])
             for ts_idx, ts in enumerate(connected_ts):
@@ -330,7 +331,7 @@ class PeakLoadWindow(Strategy):
             # add power levels to gc info
             for ts_idx, ts_info in enumerate(connected_ts):
                 ts_info["power"] += power_levels[ts_idx]
-                # adjust peak power prognose (might be reduced with batteries)
+                # adjust peak power prognosis (might be reduced with batteries)
                 if ts_info["window"] and ts_info["power"] - peak_power > self.EPS:
                     peak_power = ts_info["power"]
 

--- a/tests/test_data/input_test_cost_calculation/price_sheet.json
+++ b/tests/test_data/input_test_cost_calculation/price_sheet.json
@@ -103,7 +103,21 @@
         "unit": "ct/kWh",
         "info": "remuneration for power fed into the grid by PV power plants or electric vehicles"
     },
-    "strategy_related_cost_parameters": {
+    "strategy_related": {
+        "peak_load_window": {
+            "significance_threshold": {
+                "eHV": 5,
+                "eHV/HV": 10,
+                "HV": 10,
+                "HV/MV": 20,
+                "MV": 20,
+                "MV/LV": 30,
+                "LV": 30,
+                "unit": "%",
+                "info": ["significance threshold between overall peak power and peak power ",
+                    "inside time window to see if cost calculation for strategy can be applied"]
+            }
+        },
         "balanced_market": {
             "low_tariff_factor": 0.68,
             "medium_tariff_factor": 1,

--- a/tests/test_data/input_test_cost_calculation/price_sheet.json
+++ b/tests/test_data/input_test_cost_calculation/price_sheet.json
@@ -23,9 +23,7 @@
                     "MV/LV": 44.26,
                     "LV": 44.26,
                     "unit": "EUR/(kW*a)",
-                    "info": ["capacity charge depending on the voltage level for RLM",
-                        "(Registrierende Leistungsmessung, engl.: consumption metering) customers with",
-                        "annual utilization time < 2500 h/a"]
+                    "info": "capacity charge depending on the voltage level for RLM (Registrierende Leistungsmessung, engl.: consumption metering) customers with annual utilization time < 2500 h/a"
                 },
                 "commodity_charge_ct/kWh": {
                     "HV": 2.3,
@@ -34,9 +32,7 @@
                     "MV/LV": 4.39,
                     "LV": 4.83,
                     "unit": "ct/kWh",
-                    "info": ["commodity charge depending on the voltage level for RLM",
-                        "(Registrierende Leistungsmessung, engl.: consumption metering) customers with",
-                        "annual utilization time < 2500 h/a"]
+                    "info": "commodity charge depending on the voltage level for RLM (Registrierende Leistungsmessung, engl.: consumption metering) customers with annual utilization time < 2500 h/a"
                 }
             },
             ">=2500_h/a": {
@@ -47,8 +43,7 @@
                     "MV/LV": 97.01,
                     "LV": 64.33,
                     "unit": "EUR/(kW*a)",
-                    "info": ["capacity charge depending on the voltage level for RLM customers with",
-                        "annual utilization time >= 2500 h/a"]
+                    "info": "capacity charge depending on the voltage level for RLM customers with annual utilization time >= 2500 h/a"
                 },
                 "commodity_charge_ct/kWh": {
                     "HV": 0.81,
@@ -57,8 +52,7 @@
                     "MV/LV": 2.28,
                     "LV": 4.03,
                     "unit": "ct/kWh",
-                    "info": ["commodity charge depending on the voltage level for RLM customers with",
-                        "annual utilization time >= 2500 h/a"]
+                    "info": "commodity charge depending on the voltage level for RLM customers with annual utilization time >= 2500 h/a"
                 }
             },
             "additional_costs": {
@@ -80,7 +74,7 @@
         "offshore_levy": 0.419,
         "interruptible_loads_levy": 0.003,
         "unit": "ct/kWh",
-        "info": ["levies on energy supplied from the power grid"]
+        "info": "levies on energy supplied from the power grid"
     },
     "concession_fee": {
         "charge": 1.32,
@@ -114,25 +108,21 @@
                 "MV/LV": 30,
                 "LV": 30,
                 "unit": "%",
-                "info": ["significance threshold between overall peak power and peak power ",
-                    "inside time window to see if cost calculation for strategy can be applied"]
+                "info": "significance threshold between overall peak power and peak power inside time window to see if cost calculation for strategy can be applied"
             }
         },
         "balanced_market": {
             "low_tariff_factor": 0.68,
             "medium_tariff_factor": 1,
             "unit": "-",
-            "info": ["factor sets commodity charge for low and medium tariff window by being multiplied with the ",
-                "commodity charge in the price sheet"]
+            "info": "factor sets commodity charge for low and medium tariff window by being multiplied with the commodity charge in the price sheet"
         },
         "schedule": {
             "reduction_of_commodity_charge": 0,
             "deviation_charge": 70.14,
             "deviation_tolerance": 0.1,
             "unit": "ct/kWh (reduction_of_commodity_charge), EUR/(kW*a) (deviation_charge), - (deviation_tolerance)",
-            "info": ["'reduction of commodity charge' can be subtracted from commodity charge (reimburse flexibility), ",
-                "'deviation charge' is applied on deviations from schedule, 'deviation_tolerance' is multiplied with ",
-                "the schedule power and defines the lower limit from which a deviation is to be charged"]
+            "info": "'reduction of commodity charge' can be subtracted from commodity charge (reimburse flexibility), 'deviation charge' is applied on deviations from schedule, 'deviation_tolerance' is multiplied with the schedule power and defines the lower limit from which a deviation is to be charged"
         }
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Added cost calculation for strategy peak_load_window

Still open: TESTS
Should be added before merging into dev.

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`
- [ ] Add the description of your changes to the CHANGELOG.md in subsection with release name `## [Unreleased]` and state the PR number with `#`

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [x] Explain new functionalities in readthedocs
- [ ] Write test(s) for new patch of code
- [x] Check building of documentation with `doc/make html`
