### PR TITLE
new flag skip_flex_report

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -134,6 +134,8 @@ if __name__ == "__main__":
     parser.add_argument('--save-timeseries', help='Write timesteps to file')
     parser.add_argument('--save-results', help='Write general info to file')
     parser.add_argument('--save-soc', help='Write SoCs of vehicles to file')
+    parser.add_argument('--skip-flex-report', action='store_true',
+                        help='Skip flex band creation when generating reports.')
     parser.add_argument('--testing', help='Stores testing results', action='store_true')
     parser.add_argument('--config', help='Use config file to set arguments')
     args = parser.parse_args()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,6 +12,25 @@ def get_scenario():
     return s
 
 
+def get_simple_scenario():
+    return scenario.Scenario({
+        "scenario": {
+            "start_time": "2020-01-01T00:00:00+02:00",
+            "interval": 15,
+            "n_intervals": 10
+        },
+        "components": {
+            "grid_connectors": {
+                "GC": {
+                    "max_power": 100,
+                    "current_loads": {"fixed_load": 11},
+                    "cost": {"type": "fixed", "value": 0.1},
+                }
+            }
+        }
+    })
+
+
 def test_split_feedin():
     # no feed-in at grid connector
     assert [0, 0, 0] == report.split_feedin(grid=-6, generation=-3, cs_sum=-2, round_to_places=2)
@@ -39,33 +58,18 @@ class TestReport:
         report.aggregate_global_results(get_scenario())
 
     def test_aggregate_local_results_simple(self):
-        j = {
-            "scenario": {
-                "start_time": "2020-01-01T00:00:00+02:00",
-                "interval": 15,
-                "n_intervals": 10
-            },
-            "components": {
-                "grid_connectors": {
-                    "GC": {
-                        "max_power": 100,
-                        "current_loads": {"fixed_load": 11},
-                        "cost": {"type": "fixed", "value": 0.1},
-                    }
-                }
-            }
-        }
-        s = scenario.Scenario(j)
+        s = get_simple_scenario()
         s.run('greedy', {})
         report.generate_reports(s, {"testing": True})
         assert s.testing["avg_drawn_power"]["GC"] == 11
 
     def test_aggregate_local_results(self):
         s = get_scenario()
-        for var in ["avg_drawn", "flex_bands", "total_vehicle_cap", "avg_stand_time",
+        for var in ["avg_drawn", "total_vehicle_cap", "avg_stand_time",
                     "total_vehicle_energy", "avg_needed_energy", "perc_stand_window",
                     "avg_flex_per_window", "sum_energy_per_window", "avg_total_standing_time"]:
             setattr(s, var, {})
+        s.flex_bands = {"GC1": None}
         report.aggregate_local_results(s, 'GC1')
 
     def test_aggregate_timeseries(self):
@@ -153,3 +157,9 @@ class TestReport:
         assert (tmp_path / 'timeseries.csv').is_file()
         assert (tmp_path / 'results.json').is_file()
         assert (tmp_path / 'soc.csv').is_file()
+
+    def test_skip_flex_report(self):
+        s = get_simple_scenario()
+        s.run('greedy', {})
+        report.generate_reports(s, {"skip_flex_report": True, "testing": True})
+        assert s.flex_bands is None


### PR DESCRIPTION
Make flex band infos in report optional (skips additional flex band computation). Default: flex band is created, same as before. Set `skip_flex_report=true` to disable.