### PR TITLE
Fix: Explicitly cast battery capacity and C-rate to float

### DIFF
--- a/examples/output/scenario_generate_from_statistics.json
+++ b/examples/output/scenario_generate_from_statistics.json
@@ -102,7 +102,7 @@
     "batteries": {
       "BAT1": {
         "parent": "GC1",
-        "capacity": 350,
+        "capacity": 350.0,
         "charging_curve": [
           [
             0,

--- a/generate.py
+++ b/generate.py
@@ -65,11 +65,8 @@ def update_namespace(args):
     # prepare stationary battery
     batteries = {}
     for idx, (capacity, c_rate) in enumerate(args.battery):
-        # --- FIX START ---
-        # Converting incoming data to number (String -> Float)
         capacity = float(capacity)
         c_rate = float(c_rate)
-        # --- FIX END ---
         if capacity > 0:
             max_power = c_rate * capacity
         else:
@@ -193,7 +190,7 @@ if __name__ == '__main__':  # pragma: no cover
     parser.add_argument('--output', '-o', help='output file name (example.json)')
     parser.add_argument('--interval', metavar='MIN', type=int, default=15,
                         help='set number of minutes for each timestep (Δt)')
-    parser.add_argument('--min-soc', metavar='SOC', type=float, default=1,  # change to 1
+    parser.add_argument('--min-soc', metavar='SOC', type=float, default=0.8,
                         help='set minimum desired SOC (0 - 1) for each charging process')
     parser.add_argument('--battery', '-b', default=[], nargs=2, action='append',
                         help='add battery with specified capacity in kWh and C-rate \

--- a/generate.py
+++ b/generate.py
@@ -65,6 +65,11 @@ def update_namespace(args):
     # prepare stationary battery
     batteries = {}
     for idx, (capacity, c_rate) in enumerate(args.battery):
+        # --- FIX START ---
+        # Converting incoming data to number (String -> Float)
+        capacity = float(capacity)
+        c_rate = float(c_rate)
+        # --- FIX END ---
         if capacity > 0:
             max_power = c_rate * capacity
         else:
@@ -188,7 +193,7 @@ if __name__ == '__main__':  # pragma: no cover
     parser.add_argument('--output', '-o', help='output file name (example.json)')
     parser.add_argument('--interval', metavar='MIN', type=int, default=15,
                         help='set number of minutes for each timestep (Δt)')
-    parser.add_argument('--min-soc', metavar='SOC', type=float, default=0.8,
+    parser.add_argument('--min-soc', metavar='SOC', type=float, default=1, #change to 1
                         help='set minimum desired SOC (0 - 1) for each charging process')
     parser.add_argument('--battery', '-b', default=[], nargs=2, action='append',
                         help='add battery with specified capacity in kWh and C-rate \

--- a/generate.py
+++ b/generate.py
@@ -193,7 +193,7 @@ if __name__ == '__main__':  # pragma: no cover
     parser.add_argument('--output', '-o', help='output file name (example.json)')
     parser.add_argument('--interval', metavar='MIN', type=int, default=15,
                         help='set number of minutes for each timestep (Δt)')
-    parser.add_argument('--min-soc', metavar='SOC', type=float, default=1, #change to 1
+    parser.add_argument('--min-soc', metavar='SOC', type=float, default=1,  # change to 1
                         help='set minimum desired SOC (0 - 1) for each charging process')
     parser.add_argument('--battery', '-b', default=[], nargs=2, action='append',
                         help='add battery with specified capacity in kWh and C-rate \

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 import json
 from pathlib import Path
 import pytest
+import subprocess
 import warnings
 
 from generate import generate
@@ -212,6 +213,21 @@ class TestGenerate(TestCaseBase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             generate(Namespace(**args))
+
+    def test_generate_with_batteries(self, tmp_path):
+        # generate from command line with batteries (should cast to float)
+        # battery with capacity and c-rate
+        assert subprocess.call([
+            "python", TEST_REPO_PATH.parent / "generate.py",
+            "statistics", "--output", "/dev/null",
+            "--battery", "100", "1"
+        ]) == 0
+        # battery with variable capacity and fixed power
+        assert subprocess.call([
+            "python", TEST_REPO_PATH.parent / "generate.py",
+            "statistics", "--output", "/dev/null",
+            "--battery", "-1", "100"
+        ]) == 0
 
 
 class TestGenerateSchedule(TestCaseBase):


### PR DESCRIPTION
Fixes N/A

**Changes proposed in this pull request**:
- In `generate.py`, incoming battery arguments (`capacity` and `c_rate`) were sometimes treated as strings, causing calculation errors in power determination. This fix explicitly casts these variables to `float` before processing to ensure correct mathematical operations.

The following steps were realized (required):
- [x] Correct linting with `flake8 path_to_script`
- [x] Check if tests pass locally with `python -m pytest tests/`
- [ ] Add the description of your changes to the CHANGELOG.md in subsection with release name `## [Unreleased]` and state the PR number with `#` -> (Skipped for minor fix, happy to add if requested)

Also the following steps were realized (if applies):
- [ ] Write docstrings to your code
- [ ] Explain new functionalities in readthedocs
- [x] Write test(s) for new patch of code
- [ ] Check building of documentation with `doc/make html`
